### PR TITLE
feat(upgrade): Update to use latest version, implement optimizations

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,10 +1,11 @@
 name: Deploy Image to GHCR
 
-env:
-  DOTNET_VERSION: "6.0.x"
-
 on:
   push:
+    branches:
+      - main
+      - dev
+  pull_request:
     branches:
       - main
       - dev
@@ -27,9 +28,18 @@ jobs:
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
+      - name: "Determine image tag"
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "tag=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: "Build API Image"
         run: |
-          docker build . --tag ghcr.io/firecrawl/mineru-api:latest
-          docker image ls ghcr.io/firecrawl/mineru-api:latest
-          docker history ghcr.io/firecrawl/mineru-api:latest
-          docker push ghcr.io/firecrawl/mineru-api:latest
+          docker build . --tag ghcr.io/firecrawl/mineru-api:${{ steps.tag.outputs.tag }}
+          docker image ls ghcr.io/firecrawl/mineru-api:${{ steps.tag.outputs.tag }}
+          docker history ghcr.io/firecrawl/mineru-api:${{ steps.tag.outputs.tag }}
+          docker push ghcr.io/firecrawl/mineru-api:${{ steps.tag.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,8 @@ ENV PATH="$APP_HOME/.venv/bin:$PATH"
 # GPU/runtime performance tuning (VRAM auto-detected from GPU at runtime)
 ENV MINERU_PDF_RENDER_THREADS=8
 ENV OMP_NUM_THREADS=8
+ENV NUM_GPU_WORKERS=3
+ENV MIN_CHUNK_PAGES=3
 
 #use paddlegpu
 # RUN pip install paddlepaddle-gpu==3.0.0b1 -i https://www.paddlepaddle.org.cn/packages/stable/cu118/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ RUN poetry config virtualenvs.in-project true && \
 # Patch mineru to support batch
 COPY patch/mineru_batch.patch /tmp/mineru_batch.patch
 RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/pipeline_analyze.py < /tmp/mineru_batch.patch
+# Patch batch_analyze to cap OCR-det forward batch size (N=1 matches warmup cache)
+COPY patch/batch_analyze_det_bs.patch /tmp/batch_analyze_det_bs.patch
+RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/batch_analyze.py < /tmp/batch_analyze_det_bs.patch
 # Add the virtual environment's bin directory to PATH
 ENV PATH="$APP_HOME/.venv/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,7 @@ RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/pipeline_ana
 # Add the virtual environment's bin directory to PATH
 ENV PATH="$APP_HOME/.venv/bin:$PATH"
 
-# GPU/runtime performance tuning
-ENV MINERU_VIRTUAL_VRAM_SIZE=24
+# GPU/runtime performance tuning (VRAM auto-detected from GPU at runtime)
 ENV MINERU_PDF_RENDER_THREADS=8
 ENV OMP_NUM_THREADS=8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,16 @@ RUN poetry config virtualenvs.in-project true && \
     rm -rf /root/.cache/pypoetry && \
     rm -rf /root/.cache/pip
 
-# Patch mineru to support batch?
-#COPY patch/mineru_batch.patch /tmp/mineru_batch.patch
-#RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/pipeline_analyze.py < /tmp/mineru_batch.patch
+# Patch mineru to support batch
+COPY patch/mineru_batch.patch /tmp/mineru_batch.patch
+RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/pipeline_analyze.py < /tmp/mineru_batch.patch
 # Add the virtual environment's bin directory to PATH
 ENV PATH="$APP_HOME/.venv/bin:$PATH"
+
+# GPU/runtime performance tuning
+ENV MINERU_VIRTUAL_VRAM_SIZE=24
+ENV MINERU_PDF_RENDER_THREADS=8
+ENV OMP_NUM_THREADS=8
 
 #use paddlegpu
 # RUN pip install paddlepaddle-gpu==3.0.0b1 -i https://www.paddlepaddle.org.cn/packages/stable/cu118/

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -6,6 +6,7 @@ import concurrent.futures
 import tempfile
 import copy
 import io
+import threading
 
 import torch
 torch.backends.cudnn.benchmark = False
@@ -25,13 +26,21 @@ from pypdfium2._helpers.misc import PdfiumError
 
 from app.warmup import create_warmup_pdf, warmup_ocr_det_shapes
 
-# Single-thread executor for all GPU work. cuDNN algorithm caches are per-thread
-# (per cuDNN handle), so warmup and real inference MUST run in the same thread
-# for compiled kernels to be reused.
-_gpu_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix="gpu")
+# --- Configuration -----------------------------------------------------------
+NUM_GPU_WORKERS = int(os.environ.get("NUM_GPU_WORKERS", "3"))
+MIN_CHUNK_PAGES = int(os.environ.get("MIN_CHUNK_PAGES", "3"))
+
+# Thread pool for all GPU work.  cuDNN algorithm caches are per-thread
+# (per cuDNN handle), so warmup and real inference MUST run in the same
+# thread for compiled kernels to be reused.
+_gpu_executor = concurrent.futures.ThreadPoolExecutor(
+    max_workers=NUM_GPU_WORKERS, thread_name_prefix="gpu"
+)
 
 class TimeoutError(Exception):
     pass
+
+# --- PDF utilities -----------------------------------------------------------
 
 def _trim_pdf_to_max_pages(pdf_bytes: bytes, max_pages: int) -> bytes:
     """Return a new PDF bytes object with at most the first max_pages pages."""
@@ -64,6 +73,46 @@ def _repair_pdf(pdf_bytes: bytes) -> bytes:
         # If repair itself fails, return original bytes and let the pipeline report the error
         return pdf_bytes
 
+# --- Chunk splitting ---------------------------------------------------------
+
+def _get_chunk_count(total_pages: int) -> int:
+    """Determine how many chunks to split a PDF into.
+
+    Returns 1 (no chunking) when the document is too small to benefit.
+    """
+    if total_pages < NUM_GPU_WORKERS * MIN_CHUNK_PAGES:
+        return 1
+    return min(NUM_GPU_WORKERS, total_pages // MIN_CHUNK_PAGES)
+
+
+def _split_pdf_into_chunks(pdf_bytes: bytes, num_chunks: int) -> list:
+    """Split *pdf_bytes* into *num_chunks* smaller PDFs (as bytes).
+
+    Pages are distributed as evenly as possible; larger chunks come first
+    when there is a remainder.
+    """
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    total_pages = len(reader.pages)
+
+    base_size = total_pages // num_chunks
+    remainder = total_pages % num_chunks
+
+    chunks = []
+    page_idx = 0
+    for i in range(num_chunks):
+        chunk_size = base_size + (1 if i < remainder else 0)
+        writer = PdfWriter()
+        for _ in range(chunk_size):
+            writer.add_page(reader.pages[page_idx])
+            page_idx += 1
+        buf = io.BytesIO()
+        writer.write(buf)
+        chunks.append(buf.getvalue())
+
+    return chunks
+
+# --- Core conversion ---------------------------------------------------------
+
 def _warmup_with_inference():
     """Run a full inference pass on a synthetic PDF to pre-compile CUDA kernels.
 
@@ -72,7 +121,8 @@ def _warmup_with_inference():
     common shapes before real requests arrive, eliminating the cold-start
     penalty (observed as ~70s vs ~0.7s for OCR-det in production).
     """
-    print("Running warm-up inference to pre-compile CUDA kernels...")
+    thread = threading.current_thread().name
+    print(f"[{thread}] Running warm-up inference to pre-compile CUDA kernels...")
     start = time.time()
     pdf_bytes = create_warmup_pdf(num_pages=8)
     try:
@@ -82,10 +132,10 @@ def _warmup_with_inference():
             max_pages=None, start_time=time.time(),
         )
         elapsed = round(time.time() - start, 1)
-        print(f"Warm-up inference complete in {elapsed}s")
+        print(f"[{thread}] Warm-up inference complete in {elapsed}s")
     except Exception as e:
         elapsed = round(time.time() - start, 1)
-        print(f"Warm-up inference finished in {elapsed}s (non-critical error: {e})")
+        print(f"[{thread}] Warm-up inference finished in {elapsed}s (non-critical error: {e})")
 
 
 def _do_convert(pdf_bytes, lang, parse_method, formula_enable, table_enable, max_pages, start_time):
@@ -137,46 +187,168 @@ def _do_convert(pdf_bytes, lang, parse_method, formula_enable, table_enable, max
         }
         return md_content, metadata
 
-def convert_to_markdown(pdf_bytes, lang="en", parse_method="auto", formula_enable=True, table_enable=True, max_pages=None):
-    """Convert PDF bytes to markdown - returns the markdown string and processing metadata"""
 
-    start_time = time.time()
+def _convert_single(pdf_bytes, start_time, lang="en", parse_method="auto",
+                    formula_enable=True, table_enable=True, max_pages=None):
+    """Convert a single PDF with PdfiumError retry logic."""
     try:
-        return _do_convert(pdf_bytes, lang, parse_method, formula_enable, table_enable, max_pages, start_time)
+        return _do_convert(pdf_bytes, lang, parse_method, formula_enable,
+                           table_enable, max_pages, start_time)
     except PdfiumError as first_error:
-        # PDFium can't parse the PDF (e.g. broken xref table) — repair and retry
         repaired = _repair_pdf(pdf_bytes)
         if repaired is pdf_bytes:
             raise Exception(f"Error converting PDF to markdown: {first_error}")
         try:
-            return _do_convert(repaired, lang, parse_method, formula_enable, table_enable, max_pages, start_time)
+            return _do_convert(repaired, lang, parse_method, formula_enable,
+                               table_enable, max_pages, start_time)
         except Exception:
             raise Exception(f"Error converting PDF to markdown: {first_error}")
     except Exception as e:
         raise Exception(f"Error converting PDF to markdown: {e}")
 
-async def async_convert_to_markdown(pdf_bytes, timeout_seconds=None, **kwargs):
-    """Async wrapper with timeout support.
 
-    Uses _gpu_executor (a single-thread pool) so that all GPU inference runs in
-    the same OS thread.  cuDNN caches its algorithm selections per-handle
-    (per-thread), so keeping warmup and real inference on the same thread lets
-    previously compiled kernels be reused — eliminating the ~2 s cold-start
-    penalty per unique tensor shape.
+def convert_to_markdown(pdf_bytes, lang="en", parse_method="auto",
+                        formula_enable=True, table_enable=True, max_pages=None):
+    """Convert PDF bytes to markdown - returns the markdown string and processing metadata"""
+    return _convert_single(pdf_bytes, time.time(), lang, parse_method,
+                           formula_enable, table_enable, max_pages)
+
+# --- Chunk conversion wrappers -----------------------------------------------
+
+def _do_convert_chunk(chunk_bytes, chunk_index, num_chunks, start_time,
+                      lang, parse_method, formula_enable, table_enable):
+    """Run _do_convert for a single chunk with per-chunk logging."""
+    thread = threading.current_thread().name
+    chunk_start = time.time()
+    print(f"[{thread}] Chunk {chunk_index + 1}/{num_chunks} starting")
+    result = _do_convert(chunk_bytes, lang, parse_method, formula_enable,
+                         table_enable, None, start_time)
+    elapsed = round(time.time() - chunk_start, 1)
+    pages = result[1]["pages"]
+    print(f"[{thread}] Chunk {chunk_index + 1}/{num_chunks} done in {elapsed}s ({pages} pages)")
+    return result
+
+
+def _convert_chunk_with_retry(chunk_bytes, chunk_index, num_chunks, start_time,
+                              lang, parse_method, formula_enable, table_enable):
+    """Convert a chunk with PdfiumError retry."""
+    thread = threading.current_thread().name
+    try:
+        return _do_convert_chunk(chunk_bytes, chunk_index, num_chunks,
+                                 start_time, lang, parse_method,
+                                 formula_enable, table_enable)
+    except PdfiumError as first_error:
+        print(f"[{thread}] Chunk {chunk_index + 1}/{num_chunks} PdfiumError, retrying with repair")
+        repaired = _repair_pdf(chunk_bytes)
+        if repaired is chunk_bytes:
+            raise Exception(f"Chunk {chunk_index + 1} error: {first_error}")
+        try:
+            return _do_convert_chunk(repaired, chunk_index, num_chunks,
+                                     start_time, lang, parse_method,
+                                     formula_enable, table_enable)
+        except Exception:
+            raise Exception(f"Chunk {chunk_index + 1} error: {first_error}")
+    except Exception as e:
+        raise Exception(f"Chunk {chunk_index + 1} error: {e}")
+
+# --- Async orchestration -----------------------------------------------------
+
+async def async_convert_to_markdown(pdf_bytes, timeout_seconds=None, **kwargs):
+    """Split a PDF into chunks and process them concurrently on the GPU thread pool.
+
+    Orchestration (page counting, splitting, merging) runs on the asyncio
+    thread so that all pool threads are available for GPU work.
     """
     loop = asyncio.get_running_loop()
+    start_time = time.time()
+
+    lang = kwargs.get("lang", "en")
+    parse_method = kwargs.get("parse_method", "auto")
+    formula_enable = kwargs.get("formula_enable", True)
+    table_enable = kwargs.get("table_enable", True)
+    max_pages = kwargs.get("max_pages")
+
+    # Apply max_pages trimming upfront (CPU-only, fine on asyncio thread)
+    if max_pages is not None:
+        try:
+            max_pages_int = int(max_pages)
+        except Exception:
+            raise Exception("Invalid max_pages value; must be an integer")
+        pdf_bytes = _trim_pdf_to_max_pages(pdf_bytes, max_pages_int)
+
+    # Count pages and determine chunking strategy
+    try:
+        reader = PdfReader(io.BytesIO(pdf_bytes))
+        total_pages = len(reader.pages)
+    except Exception:
+        total_pages = 0
+
+    num_chunks = _get_chunk_count(total_pages)
+
+    async def _run():
+        nonlocal pdf_bytes
+
+        if num_chunks <= 1:
+            # Single chunk — use existing conversion path
+            return await loop.run_in_executor(
+                _gpu_executor,
+                lambda: _convert_single(
+                    pdf_bytes, start_time, lang, parse_method,
+                    formula_enable, table_enable, max_pages=None,
+                ),
+            )
+
+        # Split into chunks (CPU-only, on asyncio thread)
+        try:
+            chunks = _split_pdf_into_chunks(pdf_bytes, num_chunks)
+        except Exception as e:
+            print(f"Chunk splitting failed ({e}), falling back to single-chunk")
+            return await loop.run_in_executor(
+                _gpu_executor,
+                lambda: _convert_single(
+                    pdf_bytes, start_time, lang, parse_method,
+                    formula_enable, table_enable, max_pages=None,
+                ),
+            )
+
+        print(f"Processing {total_pages} pages in {len(chunks)} chunks")
+
+        # Submit all chunks to the thread pool concurrently
+        futures = []
+        for i, chunk in enumerate(chunks):
+            fut = loop.run_in_executor(
+                _gpu_executor,
+                lambda idx=i, c=chunk: _convert_chunk_with_retry(
+                    c, idx, len(chunks), start_time,
+                    lang=lang, parse_method=parse_method,
+                    formula_enable=formula_enable, table_enable=table_enable,
+                ),
+            )
+            futures.append(fut)
+
+        results = await asyncio.gather(*futures)
+
+        # Merge markdown in page order
+        md_content = "\n\n".join(r[0] for r in results)
+        total_processing_time_ms = round((time.time() - start_time) * 1000)
+        total_page_count = sum(r[1]["pages"] for r in results)
+        metadata = {
+            "pages": total_page_count,
+            "ocr": results[0][1]["ocr"],
+            "processing_time_ms": total_processing_time_ms,
+            "chunks": len(chunks),
+        }
+        return md_content, metadata
 
     if timeout_seconds and timeout_seconds > 0:
         try:
-            return await asyncio.wait_for(
-                loop.run_in_executor(_gpu_executor, lambda: convert_to_markdown(pdf_bytes, **kwargs)),
-                timeout=timeout_seconds
-            )
+            return await asyncio.wait_for(_run(), timeout=timeout_seconds)
         except asyncio.TimeoutError:
             raise TimeoutError(f"PDF processing timed out after {timeout_seconds} seconds")
     else:
-        return await loop.run_in_executor(_gpu_executor, lambda: convert_to_markdown(pdf_bytes, **kwargs))
+        return await _run()
 
+# --- Request handler ---------------------------------------------------------
 
 async def handler(event):
     """Main serverless handler - returns only markdown"""
@@ -187,7 +359,7 @@ async def handler(event):
         timeout = input_data.get("timeout")
         created_at = input_data.get("created_at")
         max_pages = input_data.get("max_pages")
-        
+
         # Processing options
         lang = input_data.get("lang", "en")
         parse_method = input_data.get("parse_method", "auto")
@@ -224,7 +396,7 @@ async def handler(event):
 
         # Process PDF
         pdf_bytes = base64.b64decode(base64_content)
-        
+
         md_content, metadata = await async_convert_to_markdown(
             pdf_bytes=pdf_bytes,
             timeout_seconds=timeout_seconds,
@@ -236,32 +408,63 @@ async def handler(event):
         )
 
         return {"markdown": md_content, "status": "SUCCESS", **metadata}
-        
+
     except TimeoutError as e:
         return {"error": str(e), "status": "TIMEOUT"}
     except Exception as e:
         return {"error": str(e), "status": "ERROR"}
 
+# --- Warmup ------------------------------------------------------------------
+
 def _full_warmup():
-    """Run all warmup steps.  Executed inside _gpu_executor so that cuDNN
-    algorithm caches live in the same thread that will later handle real
-    inference requests."""
-    print("Warming up pipeline models...")
+    """Primary thread warmup: model loading + inference + OCR-det shapes.
+
+    Executed inside _gpu_executor so that cuDNN algorithm caches live in the
+    same thread that will later handle real inference requests.
+    """
+    thread = threading.current_thread().name
+    print(f"[{thread}] Warming up pipeline models...")
     ModelSingleton().get_model(
         lang="en",
         formula_enable=True,
         table_enable=True
     )
-    print("Pipeline models warmed up")
+    print(f"[{thread}] Pipeline models warmed up")
     _warmup_with_inference()
     warmup_ocr_det_shapes(lang="en")
-    print("All warmup complete")
+    print(f"[{thread}] Primary warmup complete")
+
+
+def _secondary_warmup():
+    """Secondary thread warmup: inference + OCR-det shapes.
+
+    Models are already loaded (singletons).  This populates the per-thread
+    cuDNN algorithm caches.  Should be fast thanks to the process-level
+    CUDA kernel cache populated by the primary thread.
+    """
+    thread = threading.current_thread().name
+    start = time.time()
+    print(f"[{thread}] Secondary warmup starting...")
+    _warmup_with_inference()
+    warmup_ocr_det_shapes(lang="en")
+    elapsed = round(time.time() - start, 1)
+    print(f"[{thread}] Secondary warmup complete in {elapsed}s")
 
 
 if __name__ == "__main__":
-    # Run warmup inside _gpu_executor so cuDNN caches (per-thread) are
-    # populated in the SAME thread that will later run real inference.
+    print(f"GPU thread pool: {NUM_GPU_WORKERS} workers, min {MIN_CHUNK_PAGES} pages/chunk")
+
+    # Primary warmup on first thread (model loading + inference + OCR-det)
     _gpu_executor.submit(_full_warmup).result()
+
+    # Secondary warmup on remaining threads (inference + OCR-det only)
+    if NUM_GPU_WORKERS > 1:
+        print(f"Warming up {NUM_GPU_WORKERS - 1} secondary GPU threads...")
+        futs = [_gpu_executor.submit(_secondary_warmup)
+                for _ in range(NUM_GPU_WORKERS - 1)]
+        for f in concurrent.futures.as_completed(futs):
+            f.result()  # propagate exceptions
+        print("All GPU threads warmed up")
 
     if os.environ.get("DEBUG_SERVER", "false").lower() == "true":
         import uvicorn

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -17,6 +17,7 @@ from mineru.backend.pipeline.model_json_to_middle_json import result_to_middle_j
 from mineru.backend.pipeline.pipeline_analyze import ModelSingleton
 
 from pypdf import PdfReader, PdfWriter
+from pypdfium2._helpers.misc import PdfiumError
 
 class TimeoutError(Exception):
     pass
@@ -38,61 +39,86 @@ def _trim_pdf_to_max_pages(pdf_bytes: bytes, max_pages: int) -> bytes:
     writer.write(output_buffer)
     return output_buffer.getvalue()
 
+def _repair_pdf(pdf_bytes: bytes) -> bytes:
+    """Re-write the PDF through pypdf to fix structural issues (e.g. broken xref tables)."""
+    try:
+        reader = PdfReader(io.BytesIO(pdf_bytes))
+        writer = PdfWriter()
+        for page in reader.pages:
+            writer.add_page(page)
+        output = io.BytesIO()
+        writer.write(output)
+        return output.getvalue()
+    except Exception:
+        # If repair itself fails, return original bytes and let the pipeline report the error
+        return pdf_bytes
+
+def _do_convert(pdf_bytes, lang, parse_method, formula_enable, table_enable, max_pages, start_time):
+    """Core conversion logic — separated so convert_to_markdown can retry with repaired bytes."""
+    # Optionally limit to first N pages
+    if max_pages is not None:
+        try:
+            max_pages_int = int(max_pages)
+        except Exception:
+            raise Exception("Invalid max_pages value; must be an integer")
+        pdf_bytes = _trim_pdf_to_max_pages(pdf_bytes, max_pages_int)
+
+    # Analyze the PDF
+    infer_results, all_image_lists, all_pdf_docs, lang_list_result, ocr_enabled_list = pipeline_doc_analyze(
+        [pdf_bytes],
+        [lang],
+        parse_method=parse_method,
+        formula_enable=formula_enable,
+        table_enable=table_enable
+    )
+
+    # Process results
+    model_list = infer_results[0]
+    images_list = all_image_lists[0]
+    pdf_doc = all_pdf_docs[0]
+    page_count = len(pdf_doc)
+    _lang = lang_list_result[0]
+    _ocr_enable = ocr_enabled_list[0]
+
+    # Create temporary image directory for any image processing
+    with tempfile.TemporaryDirectory() as temp_dir:
+        image_writer = FileBasedDataWriter(temp_dir)
+
+        # Convert to middle JSON format
+        middle_json = pipeline_result_to_middle_json(
+            model_list, images_list, pdf_doc, image_writer,
+            _lang, _ocr_enable, formula_enable
+        )
+
+        # Generate markdown
+        pdf_info = middle_json["pdf_info"]
+        md_content = pipeline_union_make(pdf_info, MakeMode.MM_MD, "images")
+
+        processing_time_ms = round((time.time() - start_time) * 1000)
+        metadata = {
+            "pages": page_count,
+            "ocr": _ocr_enable,
+            "processing_time_ms": processing_time_ms,
+        }
+        return md_content, metadata
+
 def convert_to_markdown(pdf_bytes, lang="en", parse_method="auto", formula_enable=True, table_enable=True, max_pages=None):
     """Convert PDF bytes to markdown - returns the markdown string and processing metadata"""
 
+    start_time = time.time()
     try:
-        start_time = time.time()
-
-        # Optionally limit to first N pages
-        if max_pages is not None:
-            try:
-                max_pages_int = int(max_pages)
-            except Exception:
-                raise Exception("Invalid max_pages value; must be an integer")
-            pdf_bytes = _trim_pdf_to_max_pages(pdf_bytes, max_pages_int)
-
-        # Analyze the PDF
-        infer_results, all_image_lists, all_pdf_docs, lang_list_result, ocr_enabled_list = pipeline_doc_analyze(
-            [pdf_bytes],
-            [lang],
-            parse_method=parse_method,
-            formula_enable=formula_enable,
-            table_enable=table_enable
-        )
-
-        # Process results
-        model_list = infer_results[0]
-        images_list = all_image_lists[0]
-        pdf_doc = all_pdf_docs[0]
-        page_count = len(pdf_doc)
-        _lang = lang_list_result[0]
-        _ocr_enable = ocr_enabled_list[0]
-
-        # Create temporary image directory for any image processing
-        with tempfile.TemporaryDirectory() as temp_dir:
-            image_writer = FileBasedDataWriter(temp_dir)
-
-            # Convert to middle JSON format
-            middle_json = pipeline_result_to_middle_json(
-                model_list, images_list, pdf_doc, image_writer,
-                _lang, _ocr_enable, formula_enable
-            )
-
-            # Generate markdown
-            pdf_info = middle_json["pdf_info"]
-            md_content = pipeline_union_make(pdf_info, MakeMode.MM_MD, "images")
-
-            processing_time_ms = round((time.time() - start_time) * 1000)
-            metadata = {
-                "pages": page_count,
-                "ocr": _ocr_enable,
-                "processing_time_ms": processing_time_ms,
-            }
-            return md_content, metadata
-
+        return _do_convert(pdf_bytes, lang, parse_method, formula_enable, table_enable, max_pages, start_time)
+    except PdfiumError as first_error:
+        # PDFium can't parse the PDF (e.g. broken xref table) — repair and retry
+        repaired = _repair_pdf(pdf_bytes)
+        if repaired is pdf_bytes:
+            raise Exception(f"Error converting PDF to markdown: {first_error}")
+        try:
+            return _do_convert(repaired, lang, parse_method, formula_enable, table_enable, max_pages, start_time)
+        except Exception:
+            raise Exception(f"Error converting PDF to markdown: {first_error}")
     except Exception as e:
-        raise Exception(f"Error converting PDF to markdown: {str(e)}")
+        raise Exception(f"Error converting PDF to markdown: {e}")
 
 async def async_convert_to_markdown(pdf_bytes, timeout_seconds=None, **kwargs):
     """Async wrapper with timeout support"""

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -107,7 +107,9 @@ def _split_pdf_into_chunks(pdf_bytes: bytes, num_chunks: int) -> list:
             page_idx += 1
         buf = io.BytesIO()
         writer.write(buf)
-        chunks.append(buf.getvalue())
+        # Round-trip through pypdf to fix xref tables / dangling references
+        # that pypdfium2 can't handle in split PDFs.
+        chunks.append(_repair_pdf(buf.getvalue()))
 
     return chunks
 

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -39,9 +39,11 @@ def _trim_pdf_to_max_pages(pdf_bytes: bytes, max_pages: int) -> bytes:
     return output_buffer.getvalue()
 
 def convert_to_markdown(pdf_bytes, lang="en", parse_method="auto", formula_enable=True, table_enable=True, max_pages=None):
-    """Convert PDF bytes to markdown - returns only the markdown string"""
-    
+    """Convert PDF bytes to markdown - returns the markdown string and processing metadata"""
+
     try:
+        start_time = time.time()
+
         # Optionally limit to first N pages
         if max_pages is not None:
             try:
@@ -52,34 +54,42 @@ def convert_to_markdown(pdf_bytes, lang="en", parse_method="auto", formula_enabl
 
         # Analyze the PDF
         infer_results, all_image_lists, all_pdf_docs, lang_list_result, ocr_enabled_list = pipeline_doc_analyze(
-            [pdf_bytes], 
-            [lang], 
-            parse_method=parse_method, 
+            [pdf_bytes],
+            [lang],
+            parse_method=parse_method,
             formula_enable=formula_enable,
             table_enable=table_enable
         )
-        
+
         # Process results
         model_list = infer_results[0]
         images_list = all_image_lists[0]
         pdf_doc = all_pdf_docs[0]
         _lang = lang_list_result[0]
         _ocr_enable = ocr_enabled_list[0]
-        
+
         # Create temporary image directory for any image processing
         with tempfile.TemporaryDirectory() as temp_dir:
             image_writer = FileBasedDataWriter(temp_dir)
-            
+
             # Convert to middle JSON format
             middle_json = pipeline_result_to_middle_json(
-                model_list, images_list, pdf_doc, image_writer, 
+                model_list, images_list, pdf_doc, image_writer,
                 _lang, _ocr_enable, formula_enable
             )
-            
-            # Generate and return markdown
+
+            # Generate markdown
             pdf_info = middle_json["pdf_info"]
-            return pipeline_union_make(pdf_info, MakeMode.MM_MD, "images")
-            
+            md_content = pipeline_union_make(pdf_info, MakeMode.MM_MD, "images")
+
+            processing_time_ms = round((time.time() - start_time) * 1000)
+            metadata = {
+                "pages": len(pdf_doc),
+                "ocr": _ocr_enable,
+                "processing_time_ms": processing_time_ms,
+            }
+            return md_content, metadata
+
     except Exception as e:
         raise Exception(f"Error converting PDF to markdown: {str(e)}")
 
@@ -97,6 +107,7 @@ async def async_convert_to_markdown(pdf_bytes, timeout_seconds=None, **kwargs):
             raise TimeoutError(f"PDF processing timed out after {timeout_seconds} seconds")
     else:
         return await loop.run_in_executor(None, lambda: convert_to_markdown(pdf_bytes, **kwargs))
+
 
 async def handler(event):
     """Main serverless handler - returns only markdown"""
@@ -145,7 +156,7 @@ async def handler(event):
         # Process PDF
         pdf_bytes = base64.b64decode(base64_content)
         
-        md_content = await async_convert_to_markdown(
+        md_content, metadata = await async_convert_to_markdown(
             pdf_bytes=pdf_bytes,
             timeout_seconds=timeout_seconds,
             lang=lang,
@@ -155,7 +166,7 @@ async def handler(event):
             max_pages=max_pages
         )
 
-        return {"markdown": md_content, "status": "SUCCESS"}
+        return {"markdown": md_content, "status": "SUCCESS", **metadata}
         
     except TimeoutError as e:
         return {"error": str(e), "status": "TIMEOUT"}

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -2,6 +2,7 @@ import base64
 import os
 import time
 import asyncio
+import concurrent.futures
 import tempfile
 import copy
 import io
@@ -23,6 +24,11 @@ from pypdf import PdfReader, PdfWriter
 from pypdfium2._helpers.misc import PdfiumError
 
 from app.warmup import create_warmup_pdf, warmup_ocr_det_shapes
+
+# Single-thread executor for all GPU work. cuDNN algorithm caches are per-thread
+# (per cuDNN handle), so warmup and real inference MUST run in the same thread
+# for compiled kernels to be reused.
+_gpu_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1, thread_name_prefix="gpu")
 
 class TimeoutError(Exception):
     pass
@@ -150,19 +156,26 @@ def convert_to_markdown(pdf_bytes, lang="en", parse_method="auto", formula_enabl
         raise Exception(f"Error converting PDF to markdown: {e}")
 
 async def async_convert_to_markdown(pdf_bytes, timeout_seconds=None, **kwargs):
-    """Async wrapper with timeout support"""
+    """Async wrapper with timeout support.
+
+    Uses _gpu_executor (a single-thread pool) so that all GPU inference runs in
+    the same OS thread.  cuDNN caches its algorithm selections per-handle
+    (per-thread), so keeping warmup and real inference on the same thread lets
+    previously compiled kernels be reused — eliminating the ~2 s cold-start
+    penalty per unique tensor shape.
+    """
     loop = asyncio.get_running_loop()
-    
+
     if timeout_seconds and timeout_seconds > 0:
         try:
             return await asyncio.wait_for(
-                loop.run_in_executor(None, lambda: convert_to_markdown(pdf_bytes, **kwargs)),
+                loop.run_in_executor(_gpu_executor, lambda: convert_to_markdown(pdf_bytes, **kwargs)),
                 timeout=timeout_seconds
             )
         except asyncio.TimeoutError:
             raise TimeoutError(f"PDF processing timed out after {timeout_seconds} seconds")
     else:
-        return await loop.run_in_executor(None, lambda: convert_to_markdown(pdf_bytes, **kwargs))
+        return await loop.run_in_executor(_gpu_executor, lambda: convert_to_markdown(pdf_bytes, **kwargs))
 
 
 async def handler(event):
@@ -229,8 +242,10 @@ async def handler(event):
     except Exception as e:
         return {"error": str(e), "status": "ERROR"}
 
-if __name__ == "__main__":
-    # Warm up models and pre-compile CUDA kernels (both debug and production)
+def _full_warmup():
+    """Run all warmup steps.  Executed inside _gpu_executor so that cuDNN
+    algorithm caches live in the same thread that will later handle real
+    inference requests."""
     print("Warming up pipeline models...")
     ModelSingleton().get_model(
         lang="en",
@@ -240,6 +255,13 @@ if __name__ == "__main__":
     print("Pipeline models warmed up")
     _warmup_with_inference()
     warmup_ocr_det_shapes(lang="en")
+    print("All warmup complete")
+
+
+if __name__ == "__main__":
+    # Run warmup inside _gpu_executor so cuDNN caches (per-thread) are
+    # populated in the SAME thread that will later run real inference.
+    _gpu_executor.submit(_full_warmup).result()
 
     if os.environ.get("DEBUG_SERVER", "false").lower() == "true":
         import uvicorn

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -19,7 +19,7 @@ from mineru.backend.pipeline.pipeline_analyze import ModelSingleton
 from pypdf import PdfReader, PdfWriter
 from pypdfium2._helpers.misc import PdfiumError
 
-from app.warmup import create_warmup_pdf
+from app.warmup import create_warmup_pdf, warmup_ocr_det_shapes
 
 class TimeoutError(Exception):
     pass
@@ -236,6 +236,7 @@ if __name__ == "__main__":
     )
     print("Pipeline models warmed up")
     _warmup_with_inference()
+    warmup_ocr_det_shapes(lang="en")
 
     if os.environ.get("DEBUG_SERVER", "false").lower() == "true":
         import uvicorn

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -6,6 +6,9 @@ import tempfile
 import copy
 import io
 
+import torch
+torch.backends.cudnn.benchmark = False
+
 import runpod
 
 # New mineru imports

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -53,6 +53,117 @@ def _repair_pdf(pdf_bytes: bytes) -> bytes:
         # If repair itself fails, return original bytes and let the pipeline report the error
         return pdf_bytes
 
+def _create_warmup_pdf(num_pages=4):
+    """Create a synthetic multi-page PDF with dense text for CUDA kernel warm-up.
+
+    Generates pages with many text lines at varied font sizes so the layout model
+    detects numerous text regions, forcing OCR-det to process diverse tensor shapes
+    and pre-compile CUDA kernels for them.
+    """
+    page_obj_nums = []
+    page_content_pairs = []
+    obj_num = 4  # 1=Catalog, 2=Pages, 3=Font
+
+    for p in range(num_pages):
+        ops = ["BT"]
+        y = 760
+        for i in range(40):
+            size = 8 + (i % 5) * 2  # cycle 8, 10, 12, 14, 16 pt
+            x = 40 + (i % 3) * 10
+            text = f"P{p+1} L{i+1} The quick brown fox jumps over the lazy dog 0123456789"
+            ops.append(f"/F1 {size} Tf 1 0 0 1 {x} {y} Tm ({text}) Tj")
+            y -= size + 3
+            if y < 40:
+                break
+        ops.append("ET")
+        content_bytes = "\n".join(ops).encode("latin-1")
+
+        content_obj_num = obj_num
+        page_obj_num = obj_num + 1
+        page_content_pairs.append((content_obj_num, page_obj_num, content_bytes))
+        page_obj_nums.append(page_obj_num)
+        obj_num += 2
+
+    total_objs = obj_num
+    buf = io.BytesIO()
+    offsets = {}
+
+    def write(data):
+        if isinstance(data, str):
+            data = data.encode()
+        buf.write(data)
+
+    def start_obj(num):
+        offsets[num] = buf.tell()
+        write(f"{num} 0 obj\n")
+
+    def end_obj():
+        write(b"endobj\n")
+
+    write(b"%PDF-1.4\n")
+
+    start_obj(1)
+    write(b"<</Type/Catalog/Pages 2 0 R>>\n")
+    end_obj()
+
+    kids = " ".join(f"{n} 0 R" for n in page_obj_nums)
+    start_obj(2)
+    write(f"<</Type/Pages/Kids[{kids}]/Count {num_pages}>>\n")
+    end_obj()
+
+    start_obj(3)
+    write(b"<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>\n")
+    end_obj()
+
+    for content_obj_num, page_obj_num, content_bytes in page_content_pairs:
+        start_obj(content_obj_num)
+        write(f"<</Length {len(content_bytes)}>>\nstream\n")
+        buf.write(content_bytes)
+        write(b"\nendstream\n")
+        end_obj()
+
+        start_obj(page_obj_num)
+        write(f"<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
+              f"/Contents {content_obj_num} 0 R"
+              f"/Resources<</Font<</F1 3 0 R>>>>>>\n")
+        end_obj()
+
+    xref_offset = buf.tell()
+    write(f"xref\n0 {total_objs}\n")
+    write(b"0000000000 65535 f \r\n")
+    for i in range(1, total_objs):
+        write(f"{offsets[i]:010d} 00000 n \r\n")
+
+    write(f"trailer<</Size {total_objs}/Root 1 0 R>>\n"
+          f"startxref\n{xref_offset}\n%%EOF\n")
+
+    return buf.getvalue()
+
+
+def _warmup_with_inference():
+    """Run a full inference pass on a synthetic PDF to pre-compile CUDA kernels.
+
+    The first time GPU models encounter new tensor shapes, CUDA JIT-compiles
+    optimized kernels (~2s per shape). This warm-up forces compilation for
+    common shapes before real requests arrive, eliminating the cold-start
+    penalty (observed as ~70s vs ~0.7s for OCR-det in production).
+    """
+    print("Running warm-up inference to pre-compile CUDA kernels...")
+    start = time.time()
+    pdf_bytes = _create_warmup_pdf(num_pages=4)
+    try:
+        _do_convert(
+            pdf_bytes, lang="en", parse_method="ocr",
+            formula_enable=True, table_enable=True,
+            max_pages=None, start_time=time.time(),
+        )
+        elapsed = round(time.time() - start, 1)
+        print(f"Warm-up inference complete in {elapsed}s")
+    except Exception as e:
+        elapsed = round(time.time() - start, 1)
+        print(f"Warm-up inference finished in {elapsed}s (non-critical error: {e})")
+
+
 def _do_convert(pdf_bytes, lang, parse_method, formula_enable, table_enable, max_pages, start_time):
     """Core conversion logic — separated so convert_to_markdown can retry with repaired bytes."""
     # Optionally limit to first N pages
@@ -201,12 +312,22 @@ async def handler(event):
         return {"error": str(e), "status": "ERROR"}
 
 if __name__ == "__main__":
+    # Warm up models and pre-compile CUDA kernels (both debug and production)
+    print("Warming up pipeline models...")
+    ModelSingleton().get_model(
+        lang="en",
+        formula_enable=True,
+        table_enable=True
+    )
+    print("Pipeline models warmed up")
+    _warmup_with_inference()
+
     if os.environ.get("DEBUG_SERVER", "false").lower() == "true":
         import uvicorn
         from fastapi import FastAPI, Request
-        
+
         app = FastAPI()
-        
+
         @app.get("/health")
         async def health():
             return {"status": "ok"}
@@ -222,12 +343,4 @@ if __name__ == "__main__":
         uvicorn.run(app, host="0.0.0.0", port=8000)
     else:
         print("Starting RunPod serverless handler...")
-        print("Warming up pipeline models...")
-        ModelSingleton().get_model(
-            lang="en", 
-            formula_enable=True,
-            table_enable=True
-        )
-        print("Pipeline models warmed up")
-
-        runpod.serverless.start({"handler": handler}) 
+        runpod.serverless.start({"handler": handler})

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -107,9 +107,7 @@ def _split_pdf_into_chunks(pdf_bytes: bytes, num_chunks: int) -> list:
             page_idx += 1
         buf = io.BytesIO()
         writer.write(buf)
-        # Round-trip through pypdf to fix xref tables / dangling references
-        # that pypdfium2 can't handle in split PDFs.
-        chunks.append(_repair_pdf(buf.getvalue()))
+        chunks.append(buf.getvalue())
 
     return chunks
 
@@ -315,9 +313,13 @@ async def async_convert_to_markdown(pdf_bytes, timeout_seconds=None, **kwargs):
 
         print(f"Processing {total_pages} pages in {len(chunks)} chunks")
 
-        # Submit all chunks to the thread pool concurrently
+        # Submit chunks with a stagger to avoid concurrent pypdfium2
+        # document loading (not thread-safe).  Once past the loading
+        # phase, inference runs in parallel via GIL-releasing CUDA ops.
         futures = []
         for i, chunk in enumerate(chunks):
+            if i > 0:
+                await asyncio.sleep(1.0)
             fut = loop.run_in_executor(
                 _gpu_executor,
                 lambda idx=i, c=chunk: _convert_chunk_with_retry(

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -65,6 +65,7 @@ def convert_to_markdown(pdf_bytes, lang="en", parse_method="auto", formula_enabl
         model_list = infer_results[0]
         images_list = all_image_lists[0]
         pdf_doc = all_pdf_docs[0]
+        page_count = len(pdf_doc)
         _lang = lang_list_result[0]
         _ocr_enable = ocr_enabled_list[0]
 
@@ -84,7 +85,7 @@ def convert_to_markdown(pdf_bytes, lang="en", parse_method="auto", formula_enabl
 
             processing_time_ms = round((time.time() - start_time) * 1000)
             metadata = {
-                "pages": len(pdf_doc),
+                "pages": page_count,
                 "ocr": _ocr_enable,
                 "processing_time_ms": processing_time_ms,
             }
@@ -180,13 +181,17 @@ if __name__ == "__main__":
         
         app = FastAPI()
         
+        @app.get("/health")
+        async def health():
+            return {"status": "ok"}
+
         @app.post("/run")
         async def debug_endpoint(request: Request):
             input_data = await request.json()
             # Simulate RunPod event structure
             event = {"input": input_data}
             return await handler(event)
-            
+
         print("Starting Debug Server on port 8000...")
         uvicorn.run(app, host="0.0.0.0", port=8000)
     else:

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -19,6 +19,8 @@ from mineru.backend.pipeline.pipeline_analyze import ModelSingleton
 from pypdf import PdfReader, PdfWriter
 from pypdfium2._helpers.misc import PdfiumError
 
+from app.warmup import create_warmup_pdf
+
 class TimeoutError(Exception):
     pass
 
@@ -53,93 +55,6 @@ def _repair_pdf(pdf_bytes: bytes) -> bytes:
         # If repair itself fails, return original bytes and let the pipeline report the error
         return pdf_bytes
 
-def _create_warmup_pdf(num_pages=4):
-    """Create a synthetic multi-page PDF with dense text for CUDA kernel warm-up.
-
-    Generates pages with many text lines at varied font sizes so the layout model
-    detects numerous text regions, forcing OCR-det to process diverse tensor shapes
-    and pre-compile CUDA kernels for them.
-    """
-    page_obj_nums = []
-    page_content_pairs = []
-    obj_num = 4  # 1=Catalog, 2=Pages, 3=Font
-
-    for p in range(num_pages):
-        ops = ["BT"]
-        y = 760
-        for i in range(40):
-            size = 8 + (i % 5) * 2  # cycle 8, 10, 12, 14, 16 pt
-            x = 40 + (i % 3) * 10
-            text = f"P{p+1} L{i+1} The quick brown fox jumps over the lazy dog 0123456789"
-            ops.append(f"/F1 {size} Tf 1 0 0 1 {x} {y} Tm ({text}) Tj")
-            y -= size + 3
-            if y < 40:
-                break
-        ops.append("ET")
-        content_bytes = "\n".join(ops).encode("latin-1")
-
-        content_obj_num = obj_num
-        page_obj_num = obj_num + 1
-        page_content_pairs.append((content_obj_num, page_obj_num, content_bytes))
-        page_obj_nums.append(page_obj_num)
-        obj_num += 2
-
-    total_objs = obj_num
-    buf = io.BytesIO()
-    offsets = {}
-
-    def write(data):
-        if isinstance(data, str):
-            data = data.encode()
-        buf.write(data)
-
-    def start_obj(num):
-        offsets[num] = buf.tell()
-        write(f"{num} 0 obj\n")
-
-    def end_obj():
-        write(b"endobj\n")
-
-    write(b"%PDF-1.4\n")
-
-    start_obj(1)
-    write(b"<</Type/Catalog/Pages 2 0 R>>\n")
-    end_obj()
-
-    kids = " ".join(f"{n} 0 R" for n in page_obj_nums)
-    start_obj(2)
-    write(f"<</Type/Pages/Kids[{kids}]/Count {num_pages}>>\n")
-    end_obj()
-
-    start_obj(3)
-    write(b"<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>\n")
-    end_obj()
-
-    for content_obj_num, page_obj_num, content_bytes in page_content_pairs:
-        start_obj(content_obj_num)
-        write(f"<</Length {len(content_bytes)}>>\nstream\n")
-        buf.write(content_bytes)
-        write(b"\nendstream\n")
-        end_obj()
-
-        start_obj(page_obj_num)
-        write(f"<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
-              f"/Contents {content_obj_num} 0 R"
-              f"/Resources<</Font<</F1 3 0 R>>>>>>\n")
-        end_obj()
-
-    xref_offset = buf.tell()
-    write(f"xref\n0 {total_objs}\n")
-    write(b"0000000000 65535 f \r\n")
-    for i in range(1, total_objs):
-        write(f"{offsets[i]:010d} 00000 n \r\n")
-
-    write(f"trailer<</Size {total_objs}/Root 1 0 R>>\n"
-          f"startxref\n{xref_offset}\n%%EOF\n")
-
-    return buf.getvalue()
-
-
 def _warmup_with_inference():
     """Run a full inference pass on a synthetic PDF to pre-compile CUDA kernels.
 
@@ -150,7 +65,7 @@ def _warmup_with_inference():
     """
     print("Running warm-up inference to pre-compile CUDA kernels...")
     start = time.time()
-    pdf_bytes = _create_warmup_pdf(num_pages=4)
+    pdf_bytes = create_warmup_pdf(num_pages=8)
     try:
         _do_convert(
             pdf_bytes, lang="en", parse_method="ocr",

--- a/app/warmup.py
+++ b/app/warmup.py
@@ -1,0 +1,200 @@
+"""Synthetic PDF generation for CUDA kernel warm-up.
+
+OCR-det groups detected text regions by their padded resolution (64-pixel
+boundaries).  Each unique (height, width) pair triggers a CUDA kernel
+compilation (~2 s per shape on first encounter).  The functions here build
+a multi-page PDF with deliberately diverse layouts so the layout model
+detects many separate regions of varied bounding-box sizes, pre-compiling
+kernels for the most common shapes before real traffic arrives.
+"""
+
+import io
+
+
+def _make_page_ops(page_idx):
+    """Return PDF content-stream bytes for one warm-up page.
+
+    Eight layout strategies rotate by *page_idx % 8* so that an 8-page
+    document covers titles, columns, grids, scattered words, dense body
+    text, and many font sizes — maximising the number of distinct
+    OCR-det resolution groups produced.
+    """
+    ops = ["BT"]
+    kind = page_idx % 8
+
+    if kind == 0:
+        # Large heading + subtitle + small body + footer
+        ops.append("/F1 42 Tf 1 0 0 1 50 720 Tm (Document Title Heading) Tj")
+        ops.append("/F1 20 Tf 1 0 0 1 50 670 Tm (A subtitle line in medium font) Tj")
+        y = 610
+        for i in range(12):
+            ops.append(f"/F1 10 Tf 1 0 0 1 50 {y} Tm (Body text line {i} with enough words to span the page width nicely) Tj")
+            y -= 14
+        ops.append("/F1 7 Tf 1 0 0 1 50 80 Tm (Footer: page number and small disclaimer text) Tj")
+
+    elif kind == 1:
+        # Two-column layout — narrow region widths
+        y = 750
+        for i in range(30):
+            ops.append(f"/F1 9 Tf 1 0 0 1 40 {y} Tm (Left column line {i} text) Tj")
+            ops.append(f"/F1 9 Tf 1 0 0 1 320 {y} Tm (Right column line {i} text) Tj")
+            y -= 12
+            if y < 50:
+                break
+
+    elif kind == 2:
+        # Scattered snippets at many different font sizes
+        items = [
+            (50, 740, 48, "HUGE"), (50, 680, 36, "Large Text"),
+            (50, 630, 24, "Medium-Large"), (350, 740, 6, "tiny six pt"),
+            (350, 720, 7, "seven pt text"), (350, 700, 8, "eight pt line"),
+            (50, 580, 18, "Eighteen point"), (300, 580, 14, "Fourteen pt"),
+            (50, 520, 11, "Eleven point body text line"),
+            (300, 520, 10, "Ten pt right side"),
+            (50, 460, 20, "Twenty pt block"), (350, 460, 9, "Nine pt note"),
+            (50, 380, 16, "Sixteen"), (200, 380, 12, "Twelve"),
+            (400, 380, 8, "Eight"), (50, 300, 32, "Big"),
+            (50, 250, 7, "small footer note at bottom"),
+        ]
+        for x, y, s, t in items:
+            ops.append(f"/F1 {s} Tf 1 0 0 1 {x} {y} Tm ({t}) Tj")
+
+    elif kind == 3:
+        # Alternating large/small blocks with big gaps
+        y = 750
+        for block in range(6):
+            size = 28 if block % 2 == 0 else 8
+            lines = 2 if block % 2 == 0 else 6
+            for j in range(lines):
+                text = f"Block {block} line {j} sample text content here"
+                ops.append(f"/F1 {size} Tf 1 0 0 1 50 {y} Tm ({text}) Tj")
+                y -= size + 3
+            y -= 30  # gap between blocks
+            if y < 50:
+                break
+
+    elif kind == 4:
+        # Grid layout (table-like) — many small uniform crops
+        y = 750
+        for row in range(20):
+            for col in range(5):
+                x = 30 + col * 115
+                ops.append(f"/F1 7 Tf 1 0 0 1 {x} {y} Tm (R{row}C{col} data) Tj")
+            y -= 11
+            if y < 40:
+                break
+
+    elif kind == 5:
+        # Single isolated words scattered (many tiny regions)
+        positions = [
+            (60, 750), (200, 750), (400, 750), (500, 750),
+            (80, 650), (250, 650), (450, 650),
+            (60, 550), (180, 550), (330, 550), (480, 550),
+            (100, 450), (300, 450), (500, 450),
+            (60, 350), (220, 350), (400, 350),
+            (80, 250), (250, 250), (450, 250),
+            (60, 150), (200, 150), (370, 150), (500, 150),
+        ]
+        sizes = [8, 10, 12, 14, 16, 18, 9, 11, 13, 15, 20, 7,
+                 22, 8, 10, 24, 6, 14, 9, 28, 11, 8, 16, 10]
+        for (x, y_pos), s in zip(positions, sizes):
+            ops.append(f"/F1 {s} Tf 1 0 0 1 {x} {y_pos} Tm (Word{s}) Tj")
+
+    elif kind == 6:
+        # Dense small text (many lines, forces long narrow crops)
+        y = 770
+        for i in range(55):
+            ops.append(f"/F1 7 Tf 1 0 0 1 30 {y} Tm "
+                       f"(Line {i:03d} dense text the quick brown fox jumps over the lazy dog abcdef 0123456789) Tj")
+            y -= 10
+            if y < 20:
+                break
+
+    else:
+        # Full-width lines cycling through 15 different font sizes
+        y = 760
+        sizes = [6, 8, 10, 12, 14, 16, 18, 20, 24, 28, 32, 9, 11, 13, 15]
+        for i, s in enumerate(sizes):
+            indent = 40 + (i % 4) * 30
+            ops.append(f"/F1 {s} Tf 1 0 0 1 {indent} {y} Tm "
+                       f"(Size {s}pt sample line {i} with varied indent and content width) Tj")
+            y -= s + 8
+            if y < 40:
+                break
+
+    ops.append("ET")
+    return "\n".join(ops).encode("latin-1")
+
+
+def create_warmup_pdf(num_pages=8):
+    """Build a synthetic PDF with *num_pages* diverse layouts.
+
+    Returns raw PDF bytes ready to be fed into the MinerU pipeline.
+    """
+    page_obj_nums = []
+    page_content_pairs = []
+    obj_num = 4  # 1=Catalog, 2=Pages, 3=Font
+
+    for p in range(num_pages):
+        content_bytes = _make_page_ops(p)
+
+        content_obj_num = obj_num
+        page_obj_num = obj_num + 1
+        page_content_pairs.append((content_obj_num, page_obj_num, content_bytes))
+        page_obj_nums.append(page_obj_num)
+        obj_num += 2
+
+    total_objs = obj_num
+    buf = io.BytesIO()
+    offsets = {}
+
+    def write(data):
+        if isinstance(data, str):
+            data = data.encode()
+        buf.write(data)
+
+    def start_obj(num):
+        offsets[num] = buf.tell()
+        write(f"{num} 0 obj\n")
+
+    def end_obj():
+        write(b"endobj\n")
+
+    write(b"%PDF-1.4\n")
+
+    start_obj(1)
+    write(b"<</Type/Catalog/Pages 2 0 R>>\n")
+    end_obj()
+
+    kids = " ".join(f"{n} 0 R" for n in page_obj_nums)
+    start_obj(2)
+    write(f"<</Type/Pages/Kids[{kids}]/Count {num_pages}>>\n")
+    end_obj()
+
+    start_obj(3)
+    write(b"<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>\n")
+    end_obj()
+
+    for content_obj_num, page_obj_num, content_bytes in page_content_pairs:
+        start_obj(content_obj_num)
+        write(f"<</Length {len(content_bytes)}>>\nstream\n")
+        buf.write(content_bytes)
+        write(b"\nendstream\n")
+        end_obj()
+
+        start_obj(page_obj_num)
+        write(f"<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
+              f"/Contents {content_obj_num} 0 R"
+              f"/Resources<</Font<</F1 3 0 R>>>>>>\n")
+        end_obj()
+
+    xref_offset = buf.tell()
+    write(f"xref\n0 {total_objs}\n")
+    write(b"0000000000 65535 f \r\n")
+    for i in range(1, total_objs):
+        write(f"{offsets[i]:010d} 00000 n \r\n")
+
+    write(f"trailer<</Size {total_objs}/Root 1 0 R>>\n"
+          f"startxref\n{xref_offset}\n%%EOF\n")
+
+    return buf.getvalue()

--- a/app/warmup.py
+++ b/app/warmup.py
@@ -28,12 +28,12 @@ def warmup_ocr_det_shapes(lang="en"):
     longest side ≤ 960 and rounds both dimensions to multiples of 32.  The
     final CUDA tensor shape depends on BOTH the crop size and this transform.
 
-    This function simulates that transform for all plausible crop sizes from
-    a letter-size page at ~144 DPI (1224×1584 px), collects the unique CUDA
-    shapes (~255), and runs a dummy forward pass for each.
+    This function simulates that transform for all plausible crop sizes
+    (MinerU renders at 200 DPI), collects the unique CUDA shapes (~255), and
+    runs a dummy forward pass for each to populate cuDNN / CUDA caches.
 
-    With cudnn.benchmark=False the per-shape overhead is ~0.05 s (total ~15 s).
-    With cudnn.benchmark=True it would be ~2 s each (total ~8 min).
+    IMPORTANT: This must run in the SAME thread that will later handle real
+    inference (cuDNN caches are per-thread).  See _gpu_executor in serverless.py.
     """
     import numpy as np
     from mineru.backend.pipeline.model_init import AtomModelSingleton
@@ -80,6 +80,25 @@ def warmup_ocr_det_shapes(lang="en"):
 
     elapsed = round(time.time() - start, 1)
     print(f"OCR-det warmup complete: {total} shapes in {elapsed}s")
+
+    # Diagnostic: check if batch dimension (N>1) triggers recompilation.
+    # If N=4 takes ~2s here, batch size IS part of the cache key and we
+    # need to force N=1 in the pipeline to match warmup.
+    test_h, test_w = shapes[len(shapes) // 2]  # pick a middle shape
+    dummy = np.ones((test_h, test_w, 3), dtype=np.uint8) * 255
+    t = time.time()
+    try:
+        text_detector.batch_predict([dummy], 1)
+    except Exception:
+        pass
+    t_n1 = round(time.time() - t, 3)
+    t = time.time()
+    try:
+        text_detector.batch_predict([dummy] * 4, 4)
+    except Exception:
+        pass
+    t_n4 = round(time.time() - t, 3)
+    print(f"Batch size diagnostic: shape ({test_h},{test_w}) N=1 (cached): {t_n1}s, N=4: {t_n4}s")
 
 
 def _make_page_ops(page_idx):

--- a/app/warmup.py
+++ b/app/warmup.py
@@ -21,17 +21,19 @@ import time
 
 
 def warmup_ocr_det_shapes(lang="en"):
-    """Pre-compile CUDA kernels for OCR-det across all common input resolutions.
+    """Pre-compile CUDA kernels for OCR-det across all realistic input resolutions.
 
-    The synthetic PDF warm-up produces OCR-det resolution groups that don't
-    overlap with real documents (observed: 28 warm-up shapes vs 37 production
-    shapes with zero overlap).  This function bypasses the PDF pipeline and
-    feeds dummy images directly into the OCR-det model at every 64-px-padded
-    resolution in the typical text-region range.
+    MinerU's batch_analyze pads text-region crops to 64-px boundaries, then
+    the TextDetector preprocessor (DetResizeForTest) scales images so the
+    longest side ≤ 960 and rounds both dimensions to multiples of 32.  The
+    final CUDA tensor shape depends on BOTH the crop size and this transform.
 
-    Grid: heights 64-512 (8 values) x widths 64-1280 (20 values) = 160 shapes.
-    Shapes already compiled by the PDF warm-up run in ~0.02 s each (cached).
-    New shapes compile at ~2 s each.  Typical additional time: 2-4 minutes.
+    This function simulates that transform for all plausible crop sizes from
+    a letter-size page at ~144 DPI (1224×1584 px), collects the unique CUDA
+    shapes (~255), and runs a dummy forward pass for each.
+
+    With cudnn.benchmark=False the per-shape overhead is ~0.05 s (total ~15 s).
+    With cudnn.benchmark=True it would be ~2 s each (total ~8 min).
     """
     import numpy as np
     from mineru.backend.pipeline.model_init import AtomModelSingleton
@@ -45,17 +47,25 @@ def warmup_ocr_det_shapes(lang="en"):
     )
     text_detector = ocr_model.text_detector
 
-    # Build grid: every 64-px multiple in the common text-region range.
-    # Heights 64-512 cover single lines through large paragraphs.
-    # Widths 64-1280 cover narrow labels through full page-width blocks.
-    shapes = [
-        (h, w)
-        for h in range(64, 513, 64)
-        for w in range(64, 1281, 64)
-    ]
+    # Simulate DetResizeForTest (limit_side_len=960, limit_type='max',
+    # round to multiple of 32) on all plausible crop sizes.
+    # Crops come from batch_analyze: padded to 64-px boundaries.
+    # Page at ~144 DPI: ~1224×1584 px → crop heights up to ~1664, widths up to ~1344.
+    cuda_shapes = set()
+    for h in range(64, 1665, 64):
+        for w in range(64, 1345, 64):
+            max_side = max(h, w)
+            if max_side > 960:
+                ratio = 960.0 / max_side
+            else:
+                ratio = 1.0
+            rh = max(int(round(int(h * ratio) / 32) * 32), 32)
+            rw = max(int(round(int(w * ratio) / 32) * 32), 32)
+            cuda_shapes.add((rh, rw))
 
+    shapes = sorted(cuda_shapes)
     total = len(shapes)
-    print(f"Pre-compiling OCR-det CUDA kernels for {total} resolution shapes...")
+    print(f"Pre-compiling OCR-det for {total} CUDA shapes...")
     start = time.time()
 
     for i, (h, w) in enumerate(shapes):
@@ -64,12 +74,12 @@ def warmup_ocr_det_shapes(lang="en"):
             text_detector.batch_predict([dummy], 1)
         except Exception:
             pass
-        if (i + 1) % 40 == 0:
+        if (i + 1) % 50 == 0:
             elapsed = round(time.time() - start, 1)
             print(f"  OCR-det warmup: {i + 1}/{total} shapes ({elapsed}s)")
 
     elapsed = round(time.time() - start, 1)
-    print(f"OCR-det kernel pre-compilation complete: {total} shapes in {elapsed}s")
+    print(f"OCR-det warmup complete: {total} shapes in {elapsed}s")
 
 
 def _make_page_ops(page_idx):

--- a/app/warmup.py
+++ b/app/warmup.py
@@ -1,14 +1,75 @@
-"""Synthetic PDF generation for CUDA kernel warm-up.
+"""Warm-up utilities for CUDA kernel pre-compilation.
 
 OCR-det groups detected text regions by their padded resolution (64-pixel
 boundaries).  Each unique (height, width) pair triggers a CUDA kernel
-compilation (~2 s per shape on first encounter).  The functions here build
-a multi-page PDF with deliberately diverse layouts so the layout model
-detects many separate regions of varied bounding-box sizes, pre-compiling
-kernels for the most common shapes before real traffic arrives.
+compilation (~2 s per shape on first encounter).
+
+Two warm-up strategies are provided:
+
+1. **Synthetic PDF inference** (`create_warmup_pdf`) — runs the full pipeline
+   to warm Layout, MFD, MFR, Table, and OCR models.  However, the OCR-det
+   resolution groups produced by synthetic text rarely overlap with those
+   from real-world PDFs.
+
+2. **Direct OCR-det tensor warm-up** (`warmup_ocr_det_shapes`) — feeds dummy
+   images at every common 64-px-padded resolution directly into the OCR-det
+   model, guaranteeing kernel coverage regardless of document content.
 """
 
 import io
+import time
+
+
+def warmup_ocr_det_shapes(lang="en"):
+    """Pre-compile CUDA kernels for OCR-det across all common input resolutions.
+
+    The synthetic PDF warm-up produces OCR-det resolution groups that don't
+    overlap with real documents (observed: 28 warm-up shapes vs 37 production
+    shapes with zero overlap).  This function bypasses the PDF pipeline and
+    feeds dummy images directly into the OCR-det model at every 64-px-padded
+    resolution in the typical text-region range.
+
+    Grid: heights 64-512 (8 values) x widths 64-1280 (20 values) = 160 shapes.
+    Shapes already compiled by the PDF warm-up run in ~0.02 s each (cached).
+    New shapes compile at ~2 s each.  Typical additional time: 2-4 minutes.
+    """
+    import numpy as np
+    from mineru.backend.pipeline.model_init import AtomModelSingleton
+    from mineru.backend.pipeline.model_list import AtomicModel
+
+    atom_model_manager = AtomModelSingleton()
+    ocr_model = atom_model_manager.get_atom_model(
+        atom_model_name=AtomicModel.OCR,
+        det_db_box_thresh=0.3,
+        lang=lang,
+    )
+    text_detector = ocr_model.text_detector
+
+    # Build grid: every 64-px multiple in the common text-region range.
+    # Heights 64-512 cover single lines through large paragraphs.
+    # Widths 64-1280 cover narrow labels through full page-width blocks.
+    shapes = [
+        (h, w)
+        for h in range(64, 513, 64)
+        for w in range(64, 1281, 64)
+    ]
+
+    total = len(shapes)
+    print(f"Pre-compiling OCR-det CUDA kernels for {total} resolution shapes...")
+    start = time.time()
+
+    for i, (h, w) in enumerate(shapes):
+        dummy = np.ones((h, w, 3), dtype=np.uint8) * 255
+        try:
+            text_detector.batch_predict([dummy], 1)
+        except Exception:
+            pass
+        if (i + 1) % 40 == 0:
+            elapsed = round(time.time() - start, 1)
+            print(f"  OCR-det warmup: {i + 1}/{total} shapes ({elapsed}s)")
+
+    elapsed = round(time.time() - start, 1)
+    print(f"OCR-det kernel pre-compilation complete: {total} shapes in {elapsed}s")
 
 
 def _make_page_ops(page_idx):

--- a/patch/batch_analyze_det_bs.patch
+++ b/patch/batch_analyze_det_bs.patch
@@ -1,0 +1,30 @@
+--- /tmp/original_ba.py	2026-02-23 22:17:10
++++ /tmp/patched_ba.py	2026-02-23 22:17:34
+@@ -1,4 +1,5 @@
+ import html
++import os
+
+ import cv2
+ from loguru import logger
+@@ -14,6 +15,12 @@
+ from ...utils.ocr_utils import get_adjusted_mfdetrec_res, get_ocr_result_list, OcrConfidence, get_rotate_crop_image
+ from ...utils.pdf_image_tools import get_crop_np_img
+
++# Cap the max tensor batch size (N dimension) for OCR-det forward passes.
++# cuDNN/CUDA caches compiled kernels per (N, C, H, W).  Setting this to 1
++# ensures every forward pass uses N=1, matching the warmup kernel cache.
++# Set to 0 to disable the cap (original behaviour).
++OCR_DET_MAX_FORWARD_BATCH = int(os.environ.get("OCR_DET_MAX_FORWARD_BATCH", "1"))
++
+ YOLO_LAYOUT_BASE_BATCH_SIZE = 1
+ MFD_BASE_BATCH_SIZE = 1
+ MFR_BASE_BATCH_SIZE = 16
+@@ -307,6 +314,8 @@
+
+                     # 批处理检测
+                     det_batch_size = min(len(batch_images), self.batch_ratio * OCR_DET_BASE_BATCH_SIZE)
++                    if OCR_DET_MAX_FORWARD_BATCH > 0:
++                        det_batch_size = min(det_batch_size, OCR_DET_MAX_FORWARD_BATCH)
+                     batch_results = ocr_model.text_detector.batch_predict(batch_images, det_batch_size)
+
+                     # 处理批处理结果

--- a/patch/mineru_batch.patch
+++ b/patch/mineru_batch.patch
@@ -14,7 +14,9 @@
  
      gpu_memory = get_vram(device)
 -    if gpu_memory >= 16:
-+    if gpu_memory >= 22:
++    if gpu_memory >= 40:
++        batch_ratio = 48
++    elif gpu_memory >= 22:
 +        batch_ratio = 32
 +    elif gpu_memory >= 16:
          batch_ratio = 16

--- a/patch/mineru_batch.patch
+++ b/patch/mineru_batch.patch
@@ -9,7 +9,7 @@
  class ModelSingleton:
      _instance = None
      _models = {}
-@@ -176,7 +178,9 @@
+@@ -176,7 +178,11 @@
              ) from e
  
      gpu_memory = get_vram(device)

--- a/patch/mineru_batch.patch
+++ b/patch/mineru_batch.patch
@@ -1,5 +1,5 @@
---- original.py	2025-12-03 21:01:21.371655371 +0200
-+++ patched.py	2025-12-04 00:58:44.104708433 +0200
+--- /tmp/original_276.py	2026-02-13 12:04:52
++++ /tmp/patched_276.py	2026-02-13 12:05:10
 @@ -15,6 +15,8 @@
  os.environ['PYTORCH_ENABLE_MPS_FALLBACK'] = '1'  # 让mps可以fallback
  os.environ['NO_ALBUMENTATIONS_UPDATE'] = '1'  # 禁止albumentations检查更新
@@ -9,38 +9,47 @@
  class ModelSingleton:
      _instance = None
      _models = {}
-@@ -173,7 +175,9 @@
+@@ -176,7 +178,9 @@
              ) from e
  
      gpu_memory = get_vram(device)
 -    if gpu_memory >= 16:
-+    if gpu_memory >= 22: 
++    if gpu_memory >= 22:
 +        batch_ratio = 32
 +    elif gpu_memory >= 16:
          batch_ratio = 16
      elif gpu_memory >= 12:
          batch_ratio = 8
-@@ -188,14 +192,15 @@
-             f'You can set MINERU_VIRTUAL_VRAM_SIZE environment variable to adjust GPU memory allocation.'
+@@ -190,18 +194,20 @@
+             f'GPU Memory: {gpu_memory} GB, Batch Ratio: {batch_ratio}. '
      )
  
 -    # 检测torch的版本号
 -    import torch
 -    from packaging import version
--    if version.parse(torch.__version__) >= version.parse("2.8.0") or str(device).startswith('mps'):
+-    device_type = os.getenv("MINERU_LMDEPLOY_DEVICE", "")
+-    if (
+-            version.parse(torch.__version__) >= version.parse("2.8.0")
+-            or str(device).startswith('mps')
+-            or device_type.lower() in ["corex"]
+-    ):
 -        enable_ocr_det_batch = False
 -    else:
 -        enable_ocr_det_batch = True
--
 +    # # 检测torch的版本号
 +    # import torch
 +    # from packaging import version
-+    # if version.parse(torch.__version__) >= version.parse("2.8.0") or str(device).startswith('mps'):
++    # device_type = os.getenv("MINERU_LMDEPLOY_DEVICE", "")
++    # if (
++    #         version.parse(torch.__version__) >= version.parse("2.8.0")
++    #         or str(device).startswith('mps')
++    #         or device_type.lower() in ["corex"]
++    # ):
 +    #     enable_ocr_det_batch = False
 +    # else:
 +    #     enable_ocr_det_batch = True
 +    enable_ocr_det_batch = DET_BATCH_ENABLE
 +    print(f"enable_ocr_det_batch: {enable_ocr_det_batch}")
+ 
      batch_model = BatchAnalyze(model_manager, batch_ratio, formula_enable, table_enable, enable_ocr_det_batch)
      results = batch_model(images_with_extra_info)
- 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "mineru[pipeline] (>=2.6.6,<3.0.0)",
+    "mineru[pipeline] (>=2.7.6,<3.0.0)",
     "runpod (>=1.7.12,<2.0.0)",
     "pypdf (>=4.2.0,<6.0.0)"
 ]


### PR DESCRIPTION
## Summary
Upgrades MinerU to 2.7.6 and addresses a critical performance issue where the first request to process a PDF took ~80s while identical repeat requests took ~13s. The root cause was CUDA JIT-compiling GPU kernels on first encounter with new tensor shapes, particularly in the OCR detection step (37 resolution groups at 1.92s each vs 50 items/s once cached).

This PR adds a synthetic inference warm-up at startup that generates a 4-page text-dense PDF and runs the full pipeline in OCR mode, forcing kernel compilation before real traffic hits. It also adds auto-repair for broken PDFs via pypdf, returns processing metadata in responses, enables GPU batch optimizations (batch_ratio=32 for 24GB VRAM), and fixes warm-up not running at all in debug server mode.

## 

  - Upgrade MinerU to 2.7.6 with GPU batch processing patch (batch_ratio=32 for 24GB+ VRAM)
  - Add synthetic inference warm-up at startup to pre-compile CUDA kernels
  - Auto-repair broken PDFs via pypdf when PDFium fails (e.g. corrupt xref tables)
  - Add /health endpoint and return processing metadata (pages, ocr, processing_time_ms) in responses
  - Fix warm-up not running in debug server mode
  - CI: build PR-tagged images on pull requests
 
 ## Key changes

  - `app/serverless.py` — Refactored conversion into retryable _do_convert(), added PDF repair, synthetic warm-up PDF generation, and moved model warm-up to run in both debug and production modes
  - `Dockerfile` — Enable batch patch, set MINERU_VIRTUAL_VRAM_SIZE=24, MINERU_PDF_RENDER_THREADS=8, OMP_NUM_THREADS=8
  - `patch/mineru_batch.patch` — Updated for MinerU 2.7.6, adds 32x batch tier, forces OCR det batching via env var