### PR TITLE
feat: CUDA kernel warmup to fix cold-start latency

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,10 +1,11 @@
 name: Deploy Image to GHCR
 
-env:
-  DOTNET_VERSION: "6.0.x"
-
 on:
   push:
+    branches:
+      - main
+      - dev
+  pull_request:
     branches:
       - main
       - dev
@@ -27,9 +28,18 @@ jobs:
           username: ${{github.actor}}
           password: ${{secrets.GITHUB_TOKEN}}
 
+      - name: "Determine image tag"
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "tag=pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: "Build API Image"
         run: |
-          docker build . --tag ghcr.io/firecrawl/mineru-api:latest
-          docker image ls ghcr.io/firecrawl/mineru-api:latest
-          docker history ghcr.io/firecrawl/mineru-api:latest
-          docker push ghcr.io/firecrawl/mineru-api:latest
+          docker build . --tag ghcr.io/firecrawl/mineru-api:${{ steps.tag.outputs.tag }}
+          docker image ls ghcr.io/firecrawl/mineru-api:${{ steps.tag.outputs.tag }}
+          docker history ghcr.io/firecrawl/mineru-api:${{ steps.tag.outputs.tag }}
+          docker push ghcr.io/firecrawl/mineru-api:${{ steps.tag.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,11 @@ COPY . ./
 
 RUN /bin/bash -c "mineru-models-download -s huggingface -m pipeline"
 
+# Healthcheck: RunPod serverless starts on port 8000 after warmup completes.
+# start-period covers model loading + CUDA kernel warmup (~10 min).
+HEALTHCHECK --interval=10s --timeout=5s --start-period=600s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
+
 # Set the entry point to activate the virtual environment and run the command line tool
 ENTRYPOINT ["/bin/bash", "-c", "export MINERU_MODEL_SOURCE=local && python3 -m app.serverless"]
 # CMD ["python3", "-m", "app.serverless"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,12 @@ RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/pipeline_ana
 # Cap OCR-det forward batch size to N=1 so CUDA kernels match warmup cache
 COPY patch/batch_analyze_det_bs.patch /tmp/batch_analyze_det_bs.patch
 RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/batch_analyze.py < /tmp/batch_analyze_det_bs.patch
+# Increase Layout/MFD batch sizes from 1 to 8 for better GPU utilization
+COPY patch/batch_sizes.patch /tmp/batch_sizes.patch
+RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/batch_analyze.py < /tmp/batch_sizes.patch
+# Enable CUDA for wired table UNet model (was CPU-only)
+COPY patch/wired_table_cuda.patch /tmp/wired_table_cuda.patch
+RUN patch .venv/lib/python3.*/site-packages/mineru/model/table/rec/unet_table/utils.py < /tmp/wired_table_cuda.patch
 # Add the virtual environment's bin directory to PATH
 ENV PATH="$APP_HOME/.venv/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ RUN poetry config virtualenvs.in-project true && \
 # Patch mineru to support batch (batch_ratio=32 for 24GB VRAM, force OCR-det batching)
 COPY patch/mineru_batch.patch /tmp/mineru_batch.patch
 RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/pipeline_analyze.py < /tmp/mineru_batch.patch
+# Cap OCR-det forward batch size to N=1 so CUDA kernels match warmup cache
+COPY patch/batch_analyze_det_bs.patch /tmp/batch_analyze_det_bs.patch
+RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/batch_analyze.py < /tmp/batch_analyze_det_bs.patch
 # Add the virtual environment's bin directory to PATH
 ENV PATH="$APP_HOME/.venv/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ RUN poetry config virtualenvs.in-project true && \
     rm -rf /root/.cache/pypoetry && \
     rm -rf /root/.cache/pip
 
-# Patch mineru to support batch?
-#COPY patch/mineru_batch.patch /tmp/mineru_batch.patch
-#RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/pipeline_analyze.py < /tmp/mineru_batch.patch
+# Patch mineru to support batch (batch_ratio=32 for 24GB VRAM, force OCR-det batching)
+COPY patch/mineru_batch.patch /tmp/mineru_batch.patch
+RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/pipeline_analyze.py < /tmp/mineru_batch.patch
 # Add the virtual environment's bin directory to PATH
 ENV PATH="$APP_HOME/.venv/bin:$PATH"
 

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -236,7 +236,7 @@ def _gpu_diagnostics():
     if torch.cuda.is_available():
         info["cuda_device_name"] = torch.cuda.get_device_name(0)
         info["cuda_version"] = torch.version.cuda
-        mem = torch.cuda.get_device_properties(0).total_mem
+        mem = torch.cuda.get_device_properties(0).total_memory
         info["vram_gb"] = round(mem / (1024**3), 1)
     from mineru.utils.config_reader import get_device
     info["mineru_device"] = get_device()

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -223,7 +223,33 @@ def _full_warmup():
     print(f"[{thread}] Warmup complete")
 
 
+def _gpu_diagnostics():
+    """Print GPU/CUDA diagnostics at startup."""
+    import torch
+    info = {
+        "torch_version": torch.__version__,
+        "cuda_available": torch.cuda.is_available(),
+        "cuda_device_count": torch.cuda.device_count() if torch.cuda.is_available() else 0,
+        "cudnn_available": torch.backends.cudnn.is_available(),
+        "cudnn_version": torch.backends.cudnn.version() if torch.backends.cudnn.is_available() else None,
+    }
+    if torch.cuda.is_available():
+        info["cuda_device_name"] = torch.cuda.get_device_name(0)
+        info["cuda_version"] = torch.version.cuda
+        mem = torch.cuda.get_device_properties(0).total_mem
+        info["vram_gb"] = round(mem / (1024**3), 1)
+    from mineru.utils.config_reader import get_device
+    info["mineru_device"] = get_device()
+    for k, v in info.items():
+        print(f"  {k}: {v}")
+    return info
+
+
 if __name__ == "__main__":
+    print("=== GPU Diagnostics ===")
+    _diag = _gpu_diagnostics()
+    print("=======================")
+
     # Run all warmup on the GPU thread so cuDNN caches are reused at inference time
     _gpu_executor.submit(_full_warmup).result()
 
@@ -232,6 +258,10 @@ if __name__ == "__main__":
         from fastapi import FastAPI, Request
 
         app = FastAPI()
+
+        @app.get("/debug")
+        async def debug_info():
+            return _diag
 
         @app.post("/run")
         async def debug_endpoint(request: Request):

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -2,9 +2,14 @@ import base64
 import os
 import time
 import asyncio
+import concurrent.futures
 import tempfile
 import copy
 import io
+import threading
+
+import torch
+torch.backends.cudnn.benchmark = False
 
 import runpod
 
@@ -17,6 +22,15 @@ from mineru.backend.pipeline.model_json_to_middle_json import result_to_middle_j
 from mineru.backend.pipeline.pipeline_analyze import ModelSingleton
 
 from pypdf import PdfReader, PdfWriter
+
+from app.warmup import create_warmup_pdf, warmup_ocr_det_shapes
+
+# Thread pool for GPU work.  cuDNN algorithm caches are per-thread
+# (per cuDNN handle), so warmup and real inference MUST run in the same
+# thread for compiled kernels to be reused.
+_gpu_executor = concurrent.futures.ThreadPoolExecutor(
+    max_workers=1, thread_name_prefix="gpu"
+)
 
 class TimeoutError(Exception):
     pass
@@ -84,19 +98,23 @@ def convert_to_markdown(pdf_bytes, lang="en", parse_method="auto", formula_enabl
         raise Exception(f"Error converting PDF to markdown: {str(e)}")
 
 async def async_convert_to_markdown(pdf_bytes, timeout_seconds=None, **kwargs):
-    """Async wrapper with timeout support"""
+    """Async wrapper with timeout support.
+
+    Runs inference on _gpu_executor so it shares the same thread (and
+    cuDNN algorithm caches) that was warmed up at startup.
+    """
     loop = asyncio.get_running_loop()
-    
+
     if timeout_seconds and timeout_seconds > 0:
         try:
             return await asyncio.wait_for(
-                loop.run_in_executor(None, lambda: convert_to_markdown(pdf_bytes, **kwargs)),
+                loop.run_in_executor(_gpu_executor, lambda: convert_to_markdown(pdf_bytes, **kwargs)),
                 timeout=timeout_seconds
             )
         except asyncio.TimeoutError:
             raise TimeoutError(f"PDF processing timed out after {timeout_seconds} seconds")
     else:
-        return await loop.run_in_executor(None, lambda: convert_to_markdown(pdf_bytes, **kwargs))
+        return await loop.run_in_executor(_gpu_executor, lambda: convert_to_markdown(pdf_bytes, **kwargs))
 
 async def handler(event):
     """Main serverless handler - returns only markdown"""
@@ -162,30 +180,68 @@ async def handler(event):
     except Exception as e:
         return {"error": str(e), "status": "ERROR"}
 
+def _warmup_with_inference():
+    """Run a full inference pass on a synthetic PDF to pre-compile CUDA kernels.
+
+    The first time GPU models encounter new tensor shapes, CUDA JIT-compiles
+    optimized kernels (~2s per shape). This warm-up forces compilation for
+    common shapes before real requests arrive.
+    """
+    thread = threading.current_thread().name
+    print(f"[{thread}] Running warm-up inference to pre-compile CUDA kernels...")
+    start = time.time()
+    pdf_bytes = create_warmup_pdf(num_pages=8)
+    try:
+        convert_to_markdown(
+            pdf_bytes, lang="en", parse_method="ocr",
+            formula_enable=True, table_enable=True,
+            max_pages=None,
+        )
+        elapsed = round(time.time() - start, 1)
+        print(f"[{thread}] Warm-up inference complete in {elapsed}s")
+    except Exception as e:
+        elapsed = round(time.time() - start, 1)
+        print(f"[{thread}] Warm-up inference finished in {elapsed}s (non-critical error: {e})")
+
+
+def _full_warmup():
+    """Load models + run inference + warm OCR-det shapes on the GPU thread.
+
+    Executed inside _gpu_executor so that cuDNN algorithm caches live in the
+    same thread that will later handle real inference requests.
+    """
+    thread = threading.current_thread().name
+    print(f"[{thread}] Warming up pipeline models...")
+    ModelSingleton().get_model(
+        lang="en",
+        formula_enable=True,
+        table_enable=True
+    )
+    print(f"[{thread}] Pipeline models warmed up")
+    _warmup_with_inference()
+    warmup_ocr_det_shapes(lang="en")
+    print(f"[{thread}] Warmup complete")
+
+
 if __name__ == "__main__":
+    # Run all warmup on the GPU thread so cuDNN caches are reused at inference time
+    _gpu_executor.submit(_full_warmup).result()
+
     if os.environ.get("DEBUG_SERVER", "false").lower() == "true":
         import uvicorn
         from fastapi import FastAPI, Request
-        
+
         app = FastAPI()
-        
+
         @app.post("/run")
         async def debug_endpoint(request: Request):
             input_data = await request.json()
             # Simulate RunPod event structure
             event = {"input": input_data}
             return await handler(event)
-            
+
         print("Starting Debug Server on port 8000...")
         uvicorn.run(app, host="0.0.0.0", port=8000)
     else:
         print("Starting RunPod serverless handler...")
-        print("Warming up pipeline models...")
-        ModelSingleton().get_model(
-            lang="en", 
-            formula_enable=True,
-            table_enable=True
-        )
-        print("Pipeline models warmed up")
-
-        runpod.serverless.start({"handler": handler}) 
+        runpod.serverless.start({"handler": handler})

--- a/app/warmup.py
+++ b/app/warmup.py
@@ -1,0 +1,290 @@
+"""Warm-up utilities for CUDA kernel pre-compilation.
+
+OCR-det groups detected text regions by their padded resolution (64-pixel
+boundaries).  Each unique (height, width) pair triggers a CUDA kernel
+compilation (~2 s per shape on first encounter).
+
+Two warm-up strategies are provided:
+
+1. **Synthetic PDF inference** (`create_warmup_pdf`) — runs the full pipeline
+   to warm Layout, MFD, MFR, Table, and OCR models.  However, the OCR-det
+   resolution groups produced by synthetic text rarely overlap with those
+   from real-world PDFs.
+
+2. **Direct OCR-det tensor warm-up** (`warmup_ocr_det_shapes`) — feeds dummy
+   images at every common 64-px-padded resolution directly into the OCR-det
+   model, guaranteeing kernel coverage regardless of document content.
+"""
+
+import io
+import time
+
+
+def warmup_ocr_det_shapes(lang="en"):
+    """Pre-compile CUDA kernels for OCR-det across all realistic input resolutions.
+
+    MinerU's batch_analyze pads text-region crops to 64-px boundaries, then
+    the TextDetector preprocessor (DetResizeForTest) scales images so the
+    longest side ≤ 960 and rounds both dimensions to multiples of 32.  The
+    final CUDA tensor shape depends on BOTH the crop size and this transform.
+
+    This function simulates that transform for all plausible crop sizes
+    (MinerU renders at 200 DPI), collects the unique CUDA shapes (~255), and
+    runs a dummy forward pass for each to populate cuDNN / CUDA caches.
+
+    IMPORTANT: This must run in the SAME thread that will later handle real
+    inference (cuDNN caches are per-thread).  See _gpu_executor in serverless.py.
+    """
+    import numpy as np
+    from mineru.backend.pipeline.model_init import AtomModelSingleton
+    from mineru.backend.pipeline.model_list import AtomicModel
+
+    atom_model_manager = AtomModelSingleton()
+    ocr_model = atom_model_manager.get_atom_model(
+        atom_model_name=AtomicModel.OCR,
+        det_db_box_thresh=0.3,
+        lang=lang,
+    )
+    text_detector = ocr_model.text_detector
+
+    # Simulate DetResizeForTest (limit_side_len=960, limit_type='max',
+    # round to multiple of 32) on all plausible crop sizes.
+    # Crops come from batch_analyze: padded to 64-px boundaries.
+    # Page at ~144 DPI: ~1224×1584 px → crop heights up to ~1664, widths up to ~1344.
+    cuda_shapes = set()
+    for h in range(64, 1665, 64):
+        for w in range(64, 1345, 64):
+            max_side = max(h, w)
+            if max_side > 960:
+                ratio = 960.0 / max_side
+            else:
+                ratio = 1.0
+            rh = max(int(round(int(h * ratio) / 32) * 32), 32)
+            rw = max(int(round(int(w * ratio) / 32) * 32), 32)
+            cuda_shapes.add((rh, rw))
+
+    shapes = sorted(cuda_shapes)
+    total = len(shapes)
+    print(f"Pre-compiling OCR-det for {total} CUDA shapes...")
+    start = time.time()
+
+    for i, (h, w) in enumerate(shapes):
+        dummy = np.ones((h, w, 3), dtype=np.uint8) * 255
+        try:
+            text_detector.batch_predict([dummy], 1)
+        except Exception:
+            pass
+        if (i + 1) % 50 == 0:
+            elapsed = round(time.time() - start, 1)
+            print(f"  OCR-det warmup: {i + 1}/{total} shapes ({elapsed}s)")
+
+    elapsed = round(time.time() - start, 1)
+    print(f"OCR-det warmup complete: {total} shapes in {elapsed}s")
+
+    # Diagnostic: check if batch dimension (N>1) triggers recompilation.
+    # If N=4 takes ~2s here, batch size IS part of the cache key and we
+    # need to force N=1 in the pipeline to match warmup.
+    test_h, test_w = shapes[len(shapes) // 2]  # pick a middle shape
+    dummy = np.ones((test_h, test_w, 3), dtype=np.uint8) * 255
+    t = time.time()
+    try:
+        text_detector.batch_predict([dummy], 1)
+    except Exception:
+        pass
+    t_n1 = round(time.time() - t, 3)
+    t = time.time()
+    try:
+        text_detector.batch_predict([dummy] * 4, 4)
+    except Exception:
+        pass
+    t_n4 = round(time.time() - t, 3)
+    print(f"Batch size diagnostic: shape ({test_h},{test_w}) N=1 (cached): {t_n1}s, N=4: {t_n4}s")
+
+
+def _make_page_ops(page_idx):
+    """Return PDF content-stream bytes for one warm-up page.
+
+    Eight layout strategies rotate by *page_idx % 8* so that an 8-page
+    document covers titles, columns, grids, scattered words, dense body
+    text, and many font sizes — maximising the number of distinct
+    OCR-det resolution groups produced.
+    """
+    ops = ["BT"]
+    kind = page_idx % 8
+
+    if kind == 0:
+        # Large heading + subtitle + small body + footer
+        ops.append("/F1 42 Tf 1 0 0 1 50 720 Tm (Document Title Heading) Tj")
+        ops.append("/F1 20 Tf 1 0 0 1 50 670 Tm (A subtitle line in medium font) Tj")
+        y = 610
+        for i in range(12):
+            ops.append(f"/F1 10 Tf 1 0 0 1 50 {y} Tm (Body text line {i} with enough words to span the page width nicely) Tj")
+            y -= 14
+        ops.append("/F1 7 Tf 1 0 0 1 50 80 Tm (Footer: page number and small disclaimer text) Tj")
+
+    elif kind == 1:
+        # Two-column layout — narrow region widths
+        y = 750
+        for i in range(30):
+            ops.append(f"/F1 9 Tf 1 0 0 1 40 {y} Tm (Left column line {i} text) Tj")
+            ops.append(f"/F1 9 Tf 1 0 0 1 320 {y} Tm (Right column line {i} text) Tj")
+            y -= 12
+            if y < 50:
+                break
+
+    elif kind == 2:
+        # Scattered snippets at many different font sizes
+        items = [
+            (50, 740, 48, "HUGE"), (50, 680, 36, "Large Text"),
+            (50, 630, 24, "Medium-Large"), (350, 740, 6, "tiny six pt"),
+            (350, 720, 7, "seven pt text"), (350, 700, 8, "eight pt line"),
+            (50, 580, 18, "Eighteen point"), (300, 580, 14, "Fourteen pt"),
+            (50, 520, 11, "Eleven point body text line"),
+            (300, 520, 10, "Ten pt right side"),
+            (50, 460, 20, "Twenty pt block"), (350, 460, 9, "Nine pt note"),
+            (50, 380, 16, "Sixteen"), (200, 380, 12, "Twelve"),
+            (400, 380, 8, "Eight"), (50, 300, 32, "Big"),
+            (50, 250, 7, "small footer note at bottom"),
+        ]
+        for x, y, s, t in items:
+            ops.append(f"/F1 {s} Tf 1 0 0 1 {x} {y} Tm ({t}) Tj")
+
+    elif kind == 3:
+        # Alternating large/small blocks with big gaps
+        y = 750
+        for block in range(6):
+            size = 28 if block % 2 == 0 else 8
+            lines = 2 if block % 2 == 0 else 6
+            for j in range(lines):
+                text = f"Block {block} line {j} sample text content here"
+                ops.append(f"/F1 {size} Tf 1 0 0 1 50 {y} Tm ({text}) Tj")
+                y -= size + 3
+            y -= 30  # gap between blocks
+            if y < 50:
+                break
+
+    elif kind == 4:
+        # Grid layout (table-like) — many small uniform crops
+        y = 750
+        for row in range(20):
+            for col in range(5):
+                x = 30 + col * 115
+                ops.append(f"/F1 7 Tf 1 0 0 1 {x} {y} Tm (R{row}C{col} data) Tj")
+            y -= 11
+            if y < 40:
+                break
+
+    elif kind == 5:
+        # Single isolated words scattered (many tiny regions)
+        positions = [
+            (60, 750), (200, 750), (400, 750), (500, 750),
+            (80, 650), (250, 650), (450, 650),
+            (60, 550), (180, 550), (330, 550), (480, 550),
+            (100, 450), (300, 450), (500, 450),
+            (60, 350), (220, 350), (400, 350),
+            (80, 250), (250, 250), (450, 250),
+            (60, 150), (200, 150), (370, 150), (500, 150),
+        ]
+        sizes = [8, 10, 12, 14, 16, 18, 9, 11, 13, 15, 20, 7,
+                 22, 8, 10, 24, 6, 14, 9, 28, 11, 8, 16, 10]
+        for (x, y_pos), s in zip(positions, sizes):
+            ops.append(f"/F1 {s} Tf 1 0 0 1 {x} {y_pos} Tm (Word{s}) Tj")
+
+    elif kind == 6:
+        # Dense small text (many lines, forces long narrow crops)
+        y = 770
+        for i in range(55):
+            ops.append(f"/F1 7 Tf 1 0 0 1 30 {y} Tm "
+                       f"(Line {i:03d} dense text the quick brown fox jumps over the lazy dog abcdef 0123456789) Tj")
+            y -= 10
+            if y < 20:
+                break
+
+    else:
+        # Full-width lines cycling through 15 different font sizes
+        y = 760
+        sizes = [6, 8, 10, 12, 14, 16, 18, 20, 24, 28, 32, 9, 11, 13, 15]
+        for i, s in enumerate(sizes):
+            indent = 40 + (i % 4) * 30
+            ops.append(f"/F1 {s} Tf 1 0 0 1 {indent} {y} Tm "
+                       f"(Size {s}pt sample line {i} with varied indent and content width) Tj")
+            y -= s + 8
+            if y < 40:
+                break
+
+    ops.append("ET")
+    return "\n".join(ops).encode("latin-1")
+
+
+def create_warmup_pdf(num_pages=8):
+    """Build a synthetic PDF with *num_pages* diverse layouts.
+
+    Returns raw PDF bytes ready to be fed into the MinerU pipeline.
+    """
+    page_obj_nums = []
+    page_content_pairs = []
+    obj_num = 4  # 1=Catalog, 2=Pages, 3=Font
+
+    for p in range(num_pages):
+        content_bytes = _make_page_ops(p)
+
+        content_obj_num = obj_num
+        page_obj_num = obj_num + 1
+        page_content_pairs.append((content_obj_num, page_obj_num, content_bytes))
+        page_obj_nums.append(page_obj_num)
+        obj_num += 2
+
+    total_objs = obj_num
+    buf = io.BytesIO()
+    offsets = {}
+
+    def write(data):
+        if isinstance(data, str):
+            data = data.encode()
+        buf.write(data)
+
+    def start_obj(num):
+        offsets[num] = buf.tell()
+        write(f"{num} 0 obj\n")
+
+    def end_obj():
+        write(b"endobj\n")
+
+    write(b"%PDF-1.4\n")
+
+    start_obj(1)
+    write(b"<</Type/Catalog/Pages 2 0 R>>\n")
+    end_obj()
+
+    kids = " ".join(f"{n} 0 R" for n in page_obj_nums)
+    start_obj(2)
+    write(f"<</Type/Pages/Kids[{kids}]/Count {num_pages}>>\n")
+    end_obj()
+
+    start_obj(3)
+    write(b"<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>\n")
+    end_obj()
+
+    for content_obj_num, page_obj_num, content_bytes in page_content_pairs:
+        start_obj(content_obj_num)
+        write(f"<</Length {len(content_bytes)}>>\nstream\n")
+        buf.write(content_bytes)
+        write(b"\nendstream\n")
+        end_obj()
+
+        start_obj(page_obj_num)
+        write(f"<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]"
+              f"/Contents {content_obj_num} 0 R"
+              f"/Resources<</Font<</F1 3 0 R>>>>>>\n")
+        end_obj()
+
+    xref_offset = buf.tell()
+    write(f"xref\n0 {total_objs}\n")
+    write(b"0000000000 65535 f \r\n")
+    for i in range(1, total_objs):
+        write(f"{offsets[i]:010d} 00000 n \r\n")
+
+    write(f"trailer<</Size {total_objs}/Root 1 0 R>>\n"
+          f"startxref\n{xref_offset}\n%%EOF\n")
+
+    return buf.getvalue()

--- a/patch/batch_analyze_det_bs.patch
+++ b/patch/batch_analyze_det_bs.patch
@@ -1,0 +1,30 @@
+--- /tmp/original_ba.py	2026-02-23 22:17:10
++++ /tmp/patched_ba.py	2026-02-23 22:17:34
+@@ -1,4 +1,5 @@
+ import html
++import os
+
+ import cv2
+ from loguru import logger
+@@ -14,6 +15,12 @@
+ from ...utils.ocr_utils import get_adjusted_mfdetrec_res, get_ocr_result_list, OcrConfidence, get_rotate_crop_image
+ from ...utils.pdf_image_tools import get_crop_np_img
+
++# Cap the max tensor batch size (N dimension) for OCR-det forward passes.
++# cuDNN/CUDA caches compiled kernels per (N, C, H, W).  Setting this to 1
++# ensures every forward pass uses N=1, matching the warmup kernel cache.
++# Set to 0 to disable the cap (original behaviour).
++OCR_DET_MAX_FORWARD_BATCH = int(os.environ.get("OCR_DET_MAX_FORWARD_BATCH", "1"))
++
+ YOLO_LAYOUT_BASE_BATCH_SIZE = 1
+ MFD_BASE_BATCH_SIZE = 1
+ MFR_BASE_BATCH_SIZE = 16
+@@ -307,6 +314,8 @@
+
+                     # 批处理检测
+                     det_batch_size = min(len(batch_images), self.batch_ratio * OCR_DET_BASE_BATCH_SIZE)
++                    if OCR_DET_MAX_FORWARD_BATCH > 0:
++                        det_batch_size = min(det_batch_size, OCR_DET_MAX_FORWARD_BATCH)
+                     batch_results = ocr_model.text_detector.batch_predict(batch_images, det_batch_size)
+
+                     # 处理批处理结果

--- a/patch/batch_sizes.patch
+++ b/patch/batch_sizes.patch
@@ -1,0 +1,13 @@
+--- a/batch_analyze.py
++++ b/batch_analyze.py
+@@ -14,8 +14,8 @@
+ from ...utils.ocr_utils import get_adjusted_mfdetrec_res, get_ocr_result_list, OcrConfidence, get_rotate_crop_image
+ from ...utils.pdf_image_tools import get_crop_np_img
+
+-YOLO_LAYOUT_BASE_BATCH_SIZE = 1
+-MFD_BASE_BATCH_SIZE = 1
++YOLO_LAYOUT_BASE_BATCH_SIZE = 8
++MFD_BASE_BATCH_SIZE = 8
+ MFR_BASE_BATCH_SIZE = 16
+ OCR_DET_BASE_BATCH_SIZE = 16
+ TABLE_ORI_CLS_BATCH_SIZE = 16

--- a/patch/wired_table_cuda.patch
+++ b/patch/wired_table_cuda.patch
@@ -1,0 +1,25 @@
+--- /tmp/utils_original.py	2026-03-02 22:42:36
++++ /tmp/utils_patched.py	2026-03-02 22:43:02
+@@ -23,6 +23,7 @@
+
+ class EP(Enum):
+     CPU_EP = "CPUExecutionProvider"
++    CUDA_EP = "CUDAExecutionProvider"
+
+
+ class OrtInferSession:
+@@ -65,6 +66,16 @@
+         }
+         EP_list = [(EP.CPU_EP.value, cpu_provider_opts)]
+
++        # Use CUDA if available for GPU-accelerated inference
++        if EP.CUDA_EP.value in self.had_providers:
++            cuda_provider_opts = {
++                "device_id": 0,
++                "arena_extend_strategy": "kNextPowerOfTwo",
++                "cudnn_conv_algo_search": "EXHAUSTIVE",
++                "do_copy_in_default_stream": True,
++            }
++            EP_list.insert(0, (EP.CUDA_EP.value, cuda_provider_opts))
++
+         return EP_list


### PR DESCRIPTION
## Summary
- Pre-compile CUDA/cuDNN kernels at startup via synthetic PDF inference and OCR-det shape warming (~255 shapes)
- Pin inference to a dedicated GPU thread so warmed kernel caches are reused on real requests
- Fixes inconsistent cold-start latency (30s vs 3m) on serverless workers