### PR TITLE
feat: torch.compile for OCR det/rec inference

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,18 @@ RUN poetry config virtualenvs.in-project true && \
     rm -rf /root/.cache/pypoetry && \
     rm -rf /root/.cache/pip
 
-# Patch mineru to support batch?
-#COPY patch/mineru_batch.patch /tmp/mineru_batch.patch
-#RUN patch .venv/lib/python3.*/site-packages/mineru/backend/pipeline/pipeline_analyze.py < /tmp/mineru_batch.patch
+# Patch OCR models to support torch.compile
+COPY patch/torch_compile_ocr_det.patch /tmp/torch_compile_ocr_det.patch
+COPY patch/torch_compile_ocr_rec.patch /tmp/torch_compile_ocr_rec.patch
+RUN patch .venv/lib/python3.*/site-packages/mineru/model/utils/tools/infer/predict_det.py < /tmp/torch_compile_ocr_det.patch
+RUN patch .venv/lib/python3.*/site-packages/mineru/model/utils/tools/infer/predict_rec.py < /tmp/torch_compile_ocr_rec.patch
+
 # Add the virtual environment's bin directory to PATH
 ENV PATH="$APP_HOME/.venv/bin:$PATH"
+
+# Enable torch.compile for OCR models (set to 0 to disable)
+ENV TORCH_COMPILE=1
+ENV TORCH_COMPILE_MODE=default
 
 #use paddlegpu
 # RUN pip install paddlepaddle-gpu==3.0.0b1 -i https://www.paddlepaddle.org.cn/packages/stable/cu118/

--- a/app/serverless.py
+++ b/app/serverless.py
@@ -162,30 +162,61 @@ async def handler(event):
     except Exception as e:
         return {"error": str(e), "status": "ERROR"}
 
+def _gpu_diagnostics():
+    """Print GPU/CUDA diagnostics at startup."""
+    import torch
+    info = {
+        "torch_version": torch.__version__,
+        "cuda_available": torch.cuda.is_available(),
+        "cuda_device_count": torch.cuda.device_count() if torch.cuda.is_available() else 0,
+        "cudnn_available": torch.backends.cudnn.is_available(),
+        "cudnn_version": torch.backends.cudnn.version() if torch.backends.cudnn.is_available() else None,
+    }
+    if torch.cuda.is_available():
+        info["cuda_device_name"] = torch.cuda.get_device_name(0)
+        info["cuda_version"] = torch.version.cuda
+        mem = torch.cuda.get_device_properties(0).total_mem
+        info["vram_gb"] = round(mem / (1024**3), 1)
+    from mineru.utils.config_reader import get_device
+    info["mineru_device"] = get_device()
+    for k, v in info.items():
+        print(f"  {k}: {v}")
+    return info
+
+
 if __name__ == "__main__":
+    print("=== GPU Diagnostics ===")
+    _diag = _gpu_diagnostics()
+    print("=======================")
+
     if os.environ.get("DEBUG_SERVER", "false").lower() == "true":
         import uvicorn
         from fastapi import FastAPI, Request
-        
+
         app = FastAPI()
-        
+
+        @app.get("/debug")
+        async def debug_info():
+            return _diag
+
         @app.post("/run")
         async def debug_endpoint(request: Request):
             input_data = await request.json()
             # Simulate RunPod event structure
             event = {"input": input_data}
             return await handler(event)
-            
+
         print("Starting Debug Server on port 8000...")
         uvicorn.run(app, host="0.0.0.0", port=8000)
     else:
         print("Starting RunPod serverless handler...")
         print("Warming up pipeline models...")
         ModelSingleton().get_model(
-            lang="en", 
+            lang="en",
             formula_enable=True,
             table_enable=True
         )
         print("Pipeline models warmed up")
 
-        runpod.serverless.start({"handler": handler}) 
+        runpod.serverless.start({"handler": handler})
+ 

--- a/patch/torch_compile_ocr_det.patch
+++ b/patch/torch_compile_ocr_det.patch
@@ -1,0 +1,19 @@
+--- a/predict_det.py
++++ b/predict_det.py
+@@ -1,4 +1,5 @@
+ import sys
++import os
+
+ import numpy as np
+ import time
+@@ -119,6 +120,10 @@
+         for module in self.net.modules():
+             if hasattr(module, 'rep'):
+                 module.rep()
++        if os.environ.get("TORCH_COMPILE", "0") == "1":
++            compile_mode = os.environ.get("TORCH_COMPILE_MODE", "default")
++            print(f"[torch.compile] Compiling OCR-det model (mode={compile_mode})")
++            self.net = torch.compile(self.net, mode=compile_mode, dynamic=True)
+
+     def _batch_process_same_size(self, img_list):
+         """

--- a/patch/torch_compile_ocr_rec.patch
+++ b/patch/torch_compile_ocr_rec.patch
@@ -1,0 +1,18 @@
+--- a/predict_rec.py
++++ b/predict_rec.py
+@@ -1,3 +1,4 @@
++import os
+ from PIL import Image
+ import cv2
+ import numpy as np
+@@ -102,6 +103,10 @@
+                 else:
+                     torch.quantization.fuse_modules(module, ['conv', 'bn'], inplace=True)
+
++        if os.environ.get("TORCH_COMPILE", "0") == "1":
++            compile_mode = os.environ.get("TORCH_COMPILE_MODE", "default")
++            print(f"[torch.compile] Compiling OCR-rec model (mode={compile_mode})")
++            self.net = torch.compile(self.net, mode=compile_mode, dynamic=True)
+
+     def resize_norm_img(self, img, max_wh_ratio):
+         imgC, imgH, imgW = self.rec_image_shape


### PR DESCRIPTION
## Summary
- Patch OCR-det and OCR-rec models to use `torch.compile(dynamic=True)` for optimized GPU kernels via Triton
- Controlled via `TORCH_COMPILE` env var (set to `0` to disable)
- Compilation mode configurable via `TORCH_COMPILE_MODE` (default: `default`)
- First inference triggers compilation, subsequent calls use cached optimized kernels

Targets the two models with the most forward passes per request (OCR-det has ~255 resolution groups). YOLO models (layout/MFD) are skipped since they go through ultralytics' predict pipeline.

Pairs well with the warmup PR (#11) — warmup inference triggers compilation so real requests hit pre-compiled kernels.